### PR TITLE
RACSignal: implement a dedicated map operator.

### DIFF
--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -260,6 +260,20 @@
 	}] setNameWithFormat:@"[%@] -zipWith: %@", self.name, signal];
 }
 
+- (instancetype)map:(id (^)(id value))block {
+	NSCParameterAssert(block != nil);
+
+	return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+		return [self subscribeNext:^(id x) {
+			[subscriber sendNext:block(x)];
+		} error:^(NSError *error) {
+			[subscriber sendError:error];
+		} completed:^{
+			[subscriber sendCompleted];
+		}];
+	}] setNameWithFormat:@"[%@] -map:", self.name];
+}
+
 @end
 
 @implementation RACSignal (Subscription)


### PR DESCRIPTION
Since `-map:` is such a common operator, this specialization over the
default `-flattenMap:` implementation of `RACStream` increases the
overall performance of RAC.