### PR TITLE
RACSignal: avoid using -bind: in all operators.

### DIFF
--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -626,7 +626,8 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 - (RACSignal<NSNumber *> *)any:(BOOL (^)(id _Nullable object))predicateBlock RAC_WARN_UNUSED_RESULT;
 
 /// Sends an [NSNumber numberWithBool:YES] if all the objects the receiving 
-/// signal sends pass `predicateBlock`.
+/// signal sends pass `predicateBlock`. If the reciever errs,
+/// [NSNumber numberWithBool:NO] is sent.
 ///
 /// predicateBlock - cannot be nil.
 - (RACSignal<NSNumber *> *)all:(BOOL (^)(id _Nullable object))predicateBlock RAC_WARN_UNUSED_RESULT;

--- a/ReactiveObjC/RACSignal+Operations.m
+++ b/ReactiveObjC/RACSignal+Operations.m
@@ -1327,22 +1327,22 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 }
 
 - (RACSignal *)dematerialize {
-  return [[self bind:^{
-    return ^(RACEvent *event, BOOL *stop) {
-      switch (event.eventType) {
-        case RACEventTypeCompleted:
-          *stop = YES;
-          return [RACSignal empty];
-
-        case RACEventTypeError:
-          *stop = YES;
-          return [RACSignal error:event.error];
-
-        case RACEventTypeNext:
-          return [RACSignal return:event.value];
-      }
-    };
-  }] setNameWithFormat:@"[%@] -dematerialize", self.name];
+ return [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+	 return [self subscribeNext:^(RACEvent *event) {
+		 switch (event.eventType) {
+			 case RACEventTypeCompleted:
+				 [subscriber sendCompleted];
+			 case RACEventTypeError:
+				 [subscriber sendError:event.error];
+			 case RACEventTypeNext:
+				 [subscriber sendNext:event.value];
+		 }
+	 } error:^(NSError *error) {
+		 [subscriber sendError:error];
+	 } completed:^{
+		 [subscriber sendCompleted];
+	 }];
+ }];
 }
 
 - (RACSignal *)not {

--- a/ReactiveObjC/RACSignal+Operations.m
+++ b/ReactiveObjC/RACSignal+Operations.m
@@ -40,1361 +40,1361 @@ const NSInteger RACSignalErrorNoMatchingCase = 2;
 // disposable passed to the block is _not_ disposed, then the signal is
 // subscribed to again.
 static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), void (^error)(NSError *, RACDisposable *), void (^completed)(RACDisposable *)) {
-	next = [next copy];
-	error = [error copy];
-	completed = [completed copy];
+  next = [next copy];
+  error = [error copy];
+  completed = [completed copy];
 
-	RACCompoundDisposable *compoundDisposable = [RACCompoundDisposable compoundDisposable];
+  RACCompoundDisposable *compoundDisposable = [RACCompoundDisposable compoundDisposable];
 
-	RACSchedulerRecursiveBlock recursiveBlock = ^(void (^recurse)(void)) {
-		RACCompoundDisposable *selfDisposable = [RACCompoundDisposable compoundDisposable];
-		[compoundDisposable addDisposable:selfDisposable];
+  RACSchedulerRecursiveBlock recursiveBlock = ^(void (^recurse)(void)) {
+    RACCompoundDisposable *selfDisposable = [RACCompoundDisposable compoundDisposable];
+    [compoundDisposable addDisposable:selfDisposable];
 
-		__weak RACDisposable *weakSelfDisposable = selfDisposable;
+    __weak RACDisposable *weakSelfDisposable = selfDisposable;
 
-		RACDisposable *subscriptionDisposable = [signal subscribeNext:next error:^(NSError *e) {
-			@autoreleasepool {
-				error(e, compoundDisposable);
-				[compoundDisposable removeDisposable:weakSelfDisposable];
-			}
+    RACDisposable *subscriptionDisposable = [signal subscribeNext:next error:^(NSError *e) {
+      @autoreleasepool {
+        error(e, compoundDisposable);
+        [compoundDisposable removeDisposable:weakSelfDisposable];
+      }
 
-			recurse();
-		} completed:^{
-			@autoreleasepool {
-				completed(compoundDisposable);
-				[compoundDisposable removeDisposable:weakSelfDisposable];
-			}
+      recurse();
+    } completed:^{
+      @autoreleasepool {
+        completed(compoundDisposable);
+        [compoundDisposable removeDisposable:weakSelfDisposable];
+      }
 
-			recurse();
-		}];
+      recurse();
+    }];
 
-		[selfDisposable addDisposable:subscriptionDisposable];
-	};
+    [selfDisposable addDisposable:subscriptionDisposable];
+  };
 
-	// Subscribe once immediately, and then use recursive scheduling for any
-	// further resubscriptions.
-	recursiveBlock(^{
-		RACScheduler *recursiveScheduler = RACScheduler.currentScheduler ?: [RACScheduler scheduler];
+  // Subscribe once immediately, and then use recursive scheduling for any
+  // further resubscriptions.
+  recursiveBlock(^{
+    RACScheduler *recursiveScheduler = RACScheduler.currentScheduler ?: [RACScheduler scheduler];
 
-		RACDisposable *schedulingDisposable = [recursiveScheduler scheduleRecursiveBlock:recursiveBlock];
-		[compoundDisposable addDisposable:schedulingDisposable];
-	});
+    RACDisposable *schedulingDisposable = [recursiveScheduler scheduleRecursiveBlock:recursiveBlock];
+    [compoundDisposable addDisposable:schedulingDisposable];
+  });
 
-	return compoundDisposable;
+  return compoundDisposable;
 }
 
 @implementation RACSignal (Operations)
 
 - (RACSignal *)doNext:(void (^)(id x))block {
-	NSCParameterAssert(block != NULL);
+  NSCParameterAssert(block != NULL);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		return [self subscribeNext:^(id x) {
-			block(x);
-			[subscriber sendNext:x];
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			[subscriber sendCompleted];
-		}];
-	}] setNameWithFormat:@"[%@] -doNext:", self.name];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    return [self subscribeNext:^(id x) {
+      block(x);
+      [subscriber sendNext:x];
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -doNext:", self.name];
 }
 
 - (RACSignal *)doError:(void (^)(NSError *error))block {
-	NSCParameterAssert(block != NULL);
+  NSCParameterAssert(block != NULL);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		return [self subscribeNext:^(id x) {
-			[subscriber sendNext:x];
-		} error:^(NSError *error) {
-			block(error);
-			[subscriber sendError:error];
-		} completed:^{
-			[subscriber sendCompleted];
-		}];
-	}] setNameWithFormat:@"[%@] -doError:", self.name];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    return [self subscribeNext:^(id x) {
+      [subscriber sendNext:x];
+    } error:^(NSError *error) {
+      block(error);
+      [subscriber sendError:error];
+    } completed:^{
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -doError:", self.name];
 }
 
 - (RACSignal *)doCompleted:(void (^)(void))block {
-	NSCParameterAssert(block != NULL);
+  NSCParameterAssert(block != NULL);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		return [self subscribeNext:^(id x) {
-			[subscriber sendNext:x];
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			block();
-			[subscriber sendCompleted];
-		}];
-	}] setNameWithFormat:@"[%@] -doCompleted:", self.name];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    return [self subscribeNext:^(id x) {
+      [subscriber sendNext:x];
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      block();
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -doCompleted:", self.name];
 }
 
 - (RACSignal *)throttle:(NSTimeInterval)interval {
-	return [[self throttle:interval valuesPassingTest:^(id _) {
-		return YES;
-	}] setNameWithFormat:@"[%@] -throttle: %f", self.name, (double)interval];
+  return [[self throttle:interval valuesPassingTest:^(id _) {
+    return YES;
+  }] setNameWithFormat:@"[%@] -throttle: %f", self.name, (double)interval];
 }
 
 - (RACSignal *)throttle:(NSTimeInterval)interval valuesPassingTest:(BOOL (^)(id next))predicate {
-	NSCParameterAssert(interval >= 0);
-	NSCParameterAssert(predicate != nil);
+  NSCParameterAssert(interval >= 0);
+  NSCParameterAssert(predicate != nil);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACCompoundDisposable *compoundDisposable = [RACCompoundDisposable compoundDisposable];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACCompoundDisposable *compoundDisposable = [RACCompoundDisposable compoundDisposable];
 
-		// We may never use this scheduler, but we need to set it up ahead of
-		// time so that our scheduled blocks are run serially if we do.
-		RACScheduler *scheduler = [RACScheduler scheduler];
+    // We may never use this scheduler, but we need to set it up ahead of
+    // time so that our scheduled blocks are run serially if we do.
+    RACScheduler *scheduler = [RACScheduler scheduler];
 
-		// Information about any currently-buffered `next` event.
-		__block id nextValue = nil;
-		__block BOOL hasNextValue = NO;
-		RACSerialDisposable *nextDisposable = [[RACSerialDisposable alloc] init];
+    // Information about any currently-buffered `next` event.
+    __block id nextValue = nil;
+    __block BOOL hasNextValue = NO;
+    RACSerialDisposable *nextDisposable = [[RACSerialDisposable alloc] init];
 
-		void (^flushNext)(BOOL send) = ^(BOOL send) {
-			@synchronized (compoundDisposable) {
-				[nextDisposable.disposable dispose];
+    void (^flushNext)(BOOL send) = ^(BOOL send) {
+      @synchronized (compoundDisposable) {
+        [nextDisposable.disposable dispose];
 
-				if (!hasNextValue) return;
-				if (send) [subscriber sendNext:nextValue];
+        if (!hasNextValue) return;
+        if (send) [subscriber sendNext:nextValue];
 
-				nextValue = nil;
-				hasNextValue = NO;
-			}
-		};
+        nextValue = nil;
+        hasNextValue = NO;
+      }
+    };
 
-		RACDisposable *subscriptionDisposable = [self subscribeNext:^(id x) {
-			RACScheduler *delayScheduler = RACScheduler.currentScheduler ?: scheduler;
-			BOOL shouldThrottle = predicate(x);
+    RACDisposable *subscriptionDisposable = [self subscribeNext:^(id x) {
+      RACScheduler *delayScheduler = RACScheduler.currentScheduler ?: scheduler;
+      BOOL shouldThrottle = predicate(x);
 
-			@synchronized (compoundDisposable) {
-				flushNext(NO);
-				if (!shouldThrottle) {
-					[subscriber sendNext:x];
-					return;
-				}
+      @synchronized (compoundDisposable) {
+        flushNext(NO);
+        if (!shouldThrottle) {
+          [subscriber sendNext:x];
+          return;
+        }
 
-				nextValue = x;
-				hasNextValue = YES;
-				nextDisposable.disposable = [delayScheduler afterDelay:interval schedule:^{
-					flushNext(YES);
-				}];
-			}
-		} error:^(NSError *error) {
-			[compoundDisposable dispose];
-			[subscriber sendError:error];
-		} completed:^{
-			flushNext(YES);
-			[subscriber sendCompleted];
-		}];
+        nextValue = x;
+        hasNextValue = YES;
+        nextDisposable.disposable = [delayScheduler afterDelay:interval schedule:^{
+          flushNext(YES);
+        }];
+      }
+    } error:^(NSError *error) {
+      [compoundDisposable dispose];
+      [subscriber sendError:error];
+    } completed:^{
+      flushNext(YES);
+      [subscriber sendCompleted];
+    }];
 
-		[compoundDisposable addDisposable:subscriptionDisposable];
-		return compoundDisposable;
-	}] setNameWithFormat:@"[%@] -throttle: %f valuesPassingTest:", self.name, (double)interval];
+    [compoundDisposable addDisposable:subscriptionDisposable];
+    return compoundDisposable;
+  }] setNameWithFormat:@"[%@] -throttle: %f valuesPassingTest:", self.name, (double)interval];
 }
 
 - (RACSignal *)delay:(NSTimeInterval)interval {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
 
-		// We may never use this scheduler, but we need to set it up ahead of
-		// time so that our scheduled blocks are run serially if we do.
-		RACScheduler *scheduler = [RACScheduler scheduler];
+    // We may never use this scheduler, but we need to set it up ahead of
+    // time so that our scheduled blocks are run serially if we do.
+    RACScheduler *scheduler = [RACScheduler scheduler];
 
-		void (^schedule)(dispatch_block_t) = ^(dispatch_block_t block) {
-			RACScheduler *delayScheduler = RACScheduler.currentScheduler ?: scheduler;
-			RACDisposable *schedulerDisposable = [delayScheduler afterDelay:interval schedule:block];
-			[disposable addDisposable:schedulerDisposable];
-		};
+    void (^schedule)(dispatch_block_t) = ^(dispatch_block_t block) {
+      RACScheduler *delayScheduler = RACScheduler.currentScheduler ?: scheduler;
+      RACDisposable *schedulerDisposable = [delayScheduler afterDelay:interval schedule:block];
+      [disposable addDisposable:schedulerDisposable];
+    };
 
-		RACDisposable *subscriptionDisposable = [self subscribeNext:^(id x) {
-			schedule(^{
-				[subscriber sendNext:x];
-			});
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			schedule(^{
-				[subscriber sendCompleted];
-			});
-		}];
+    RACDisposable *subscriptionDisposable = [self subscribeNext:^(id x) {
+      schedule(^{
+        [subscriber sendNext:x];
+      });
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      schedule(^{
+        [subscriber sendCompleted];
+      });
+    }];
 
-		[disposable addDisposable:subscriptionDisposable];
-		return disposable;
-	}] setNameWithFormat:@"[%@] -delay: %f", self.name, (double)interval];
+    [disposable addDisposable:subscriptionDisposable];
+    return disposable;
+  }] setNameWithFormat:@"[%@] -delay: %f", self.name, (double)interval];
 }
 
 - (RACSignal *)repeat {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		return subscribeForever(self,
-			^(id x) {
-				[subscriber sendNext:x];
-			},
-			^(NSError *error, RACDisposable *disposable) {
-				[disposable dispose];
-				[subscriber sendError:error];
-			},
-			^(RACDisposable *disposable) {
-				// Resubscribe.
-			});
-	}] setNameWithFormat:@"[%@] -repeat", self.name];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    return subscribeForever(self,
+      ^(id x) {
+        [subscriber sendNext:x];
+      },
+      ^(NSError *error, RACDisposable *disposable) {
+        [disposable dispose];
+        [subscriber sendError:error];
+      },
+      ^(RACDisposable *disposable) {
+        // Resubscribe.
+      });
+  }] setNameWithFormat:@"[%@] -repeat", self.name];
 }
 
 - (RACSignal *)catch:(RACSignal * (^)(NSError *error))catchBlock {
-	NSCParameterAssert(catchBlock != NULL);
+  NSCParameterAssert(catchBlock != NULL);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACSerialDisposable *catchDisposable = [[RACSerialDisposable alloc] init];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACSerialDisposable *catchDisposable = [[RACSerialDisposable alloc] init];
 
-		RACDisposable *subscriptionDisposable = [self subscribeNext:^(id x) {
-			[subscriber sendNext:x];
-		} error:^(NSError *error) {
-			RACSignal *signal = catchBlock(error);
-			NSCAssert(signal != nil, @"Expected non-nil signal from catch block on %@", self);
-			catchDisposable.disposable = [signal subscribe:subscriber];
-		} completed:^{
-			[subscriber sendCompleted];
-		}];
+    RACDisposable *subscriptionDisposable = [self subscribeNext:^(id x) {
+      [subscriber sendNext:x];
+    } error:^(NSError *error) {
+      RACSignal *signal = catchBlock(error);
+      NSCAssert(signal != nil, @"Expected non-nil signal from catch block on %@", self);
+      catchDisposable.disposable = [signal subscribe:subscriber];
+    } completed:^{
+      [subscriber sendCompleted];
+    }];
 
-		return [RACDisposable disposableWithBlock:^{
-			[catchDisposable dispose];
-			[subscriptionDisposable dispose];
-		}];
-	}] setNameWithFormat:@"[%@] -catch:", self.name];
+    return [RACDisposable disposableWithBlock:^{
+      [catchDisposable dispose];
+      [subscriptionDisposable dispose];
+    }];
+  }] setNameWithFormat:@"[%@] -catch:", self.name];
 }
 
 - (RACSignal *)catchTo:(RACSignal *)signal {
-	return [[self catch:^(NSError *error) {
-		return signal;
-	}] setNameWithFormat:@"[%@] -catchTo: %@", self.name, signal];
+  return [[self catch:^(NSError *error) {
+    return signal;
+  }] setNameWithFormat:@"[%@] -catchTo: %@", self.name, signal];
 }
 
 + (RACSignal *)try:(id (^)(NSError **errorPtr))tryBlock {
-	NSCParameterAssert(tryBlock != NULL);
+  NSCParameterAssert(tryBlock != NULL);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		NSError *error;
-		id value = tryBlock(&error);
-		RACSignal *signal = (value == nil ? [RACSignal error:error] : [RACSignal return:value]);
-		return [signal subscribe:subscriber];
-	}] setNameWithFormat:@"+try:"];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    NSError *error;
+    id value = tryBlock(&error);
+    RACSignal *signal = (value == nil ? [RACSignal error:error] : [RACSignal return:value]);
+    return [signal subscribe:subscriber];
+  }] setNameWithFormat:@"+try:"];
 }
 
 - (RACSignal *)try:(BOOL (^)(id value, NSError **errorPtr))tryBlock {
-	NSCParameterAssert(tryBlock != NULL);
+  NSCParameterAssert(tryBlock != NULL);
 
-	return [[self flattenMap:^(id value) {
-		NSError *error = nil;
-		BOOL passed = tryBlock(value, &error);
-		return (passed ? [RACSignal return:value] : [RACSignal error:error]);
-	}] setNameWithFormat:@"[%@] -try:", self.name];
+  return [[self flattenMap:^(id value) {
+    NSError *error = nil;
+    BOOL passed = tryBlock(value, &error);
+    return (passed ? [RACSignal return:value] : [RACSignal error:error]);
+  }] setNameWithFormat:@"[%@] -try:", self.name];
 }
 
 - (RACSignal *)tryMap:(id (^)(id value, NSError **errorPtr))mapBlock {
-	NSCParameterAssert(mapBlock != NULL);
+  NSCParameterAssert(mapBlock != NULL);
 
-	return [[self flattenMap:^(id value) {
-		NSError *error = nil;
-		id mappedValue = mapBlock(value, &error);
-		return (mappedValue == nil ? [RACSignal error:error] : [RACSignal return:mappedValue]);
-	}] setNameWithFormat:@"[%@] -tryMap:", self.name];
+  return [[self flattenMap:^(id value) {
+    NSError *error = nil;
+    id mappedValue = mapBlock(value, &error);
+    return (mappedValue == nil ? [RACSignal error:error] : [RACSignal return:mappedValue]);
+  }] setNameWithFormat:@"[%@] -tryMap:", self.name];
 }
 
 - (RACSignal *)initially:(void (^)(void))block {
-	NSCParameterAssert(block != NULL);
+  NSCParameterAssert(block != NULL);
 
-	return [[RACSignal defer:^{
-		block();
-		return self;
-	}] setNameWithFormat:@"[%@] -initially:", self.name];
+  return [[RACSignal defer:^{
+    block();
+    return self;
+  }] setNameWithFormat:@"[%@] -initially:", self.name];
 }
 
 - (RACSignal *)finally:(void (^)(void))block {
-	NSCParameterAssert(block != NULL);
+  NSCParameterAssert(block != NULL);
 
-	return [[[self
-		doError:^(NSError *error) {
-			block();
-		}]
-		doCompleted:^{
-			block();
-		}]
-		setNameWithFormat:@"[%@] -finally:", self.name];
+  return [[[self
+    doError:^(NSError *error) {
+      block();
+    }]
+    doCompleted:^{
+      block();
+    }]
+    setNameWithFormat:@"[%@] -finally:", self.name];
 }
 
 - (RACSignal *)bufferWithTime:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler {
-	NSCParameterAssert(scheduler != nil);
-	NSCParameterAssert(scheduler != RACScheduler.immediateScheduler);
+  NSCParameterAssert(scheduler != nil);
+  NSCParameterAssert(scheduler != RACScheduler.immediateScheduler);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACSerialDisposable *timerDisposable = [[RACSerialDisposable alloc] init];
-		NSMutableArray *values = [NSMutableArray array];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACSerialDisposable *timerDisposable = [[RACSerialDisposable alloc] init];
+    NSMutableArray *values = [NSMutableArray array];
 
-		void (^flushValues)() = ^{
-			@synchronized (values) {
-				[timerDisposable.disposable dispose];
+    void (^flushValues)() = ^{
+      @synchronized (values) {
+        [timerDisposable.disposable dispose];
 
-				if (values.count == 0) return;
+        if (values.count == 0) return;
 
-				RACTuple *tuple = [RACTuple tupleWithObjectsFromArray:values];
-				[values removeAllObjects];
-				[subscriber sendNext:tuple];
-			}
-		};
+        RACTuple *tuple = [RACTuple tupleWithObjectsFromArray:values];
+        [values removeAllObjects];
+        [subscriber sendNext:tuple];
+      }
+    };
 
-		RACDisposable *selfDisposable = [self subscribeNext:^(id x) {
-			@synchronized (values) {
-				if (values.count == 0) {
-					timerDisposable.disposable = [scheduler afterDelay:interval schedule:flushValues];
-				}
+    RACDisposable *selfDisposable = [self subscribeNext:^(id x) {
+      @synchronized (values) {
+        if (values.count == 0) {
+          timerDisposable.disposable = [scheduler afterDelay:interval schedule:flushValues];
+        }
 
-				[values addObject:x ?: RACTupleNil.tupleNil];
-			}
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			flushValues();
-			[subscriber sendCompleted];
-		}];
+        [values addObject:x ?: RACTupleNil.tupleNil];
+      }
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      flushValues();
+      [subscriber sendCompleted];
+    }];
 
-		return [RACDisposable disposableWithBlock:^{
-			[selfDisposable dispose];
-			[timerDisposable dispose];
-		}];
-	}] setNameWithFormat:@"[%@] -bufferWithTime: %f onScheduler: %@", self.name, (double)interval, scheduler];
+    return [RACDisposable disposableWithBlock:^{
+      [selfDisposable dispose];
+      [timerDisposable dispose];
+    }];
+  }] setNameWithFormat:@"[%@] -bufferWithTime: %f onScheduler: %@", self.name, (double)interval, scheduler];
 }
 
 - (RACSignal *)collect {
-	return [[self aggregateWithStartFactory:^{
-		return [[NSMutableArray alloc] init];
-	} reduce:^(NSMutableArray *collectedValues, id x) {
-		[collectedValues addObject:(x ?: NSNull.null)];
-		return collectedValues;
-	}] setNameWithFormat:@"[%@] -collect", self.name];
+  return [[self aggregateWithStartFactory:^{
+    return [[NSMutableArray alloc] init];
+  } reduce:^(NSMutableArray *collectedValues, id x) {
+    [collectedValues addObject:(x ?: NSNull.null)];
+    return collectedValues;
+  }] setNameWithFormat:@"[%@] -collect", self.name];
 }
 
 - (RACSignal *)takeLast:(NSUInteger)count {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		NSMutableArray *valuesTaken = [NSMutableArray arrayWithCapacity:count];
-		return [self subscribeNext:^(id x) {
-			[valuesTaken addObject:x ? : RACTupleNil.tupleNil];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    NSMutableArray *valuesTaken = [NSMutableArray arrayWithCapacity:count];
+    return [self subscribeNext:^(id x) {
+      [valuesTaken addObject:x ? : RACTupleNil.tupleNil];
 
-			while (valuesTaken.count > count) {
-				[valuesTaken removeObjectAtIndex:0];
-			}
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			for (id value in valuesTaken) {
-				[subscriber sendNext:value == RACTupleNil.tupleNil ? nil : value];
-			}
+      while (valuesTaken.count > count) {
+        [valuesTaken removeObjectAtIndex:0];
+      }
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      for (id value in valuesTaken) {
+        [subscriber sendNext:value == RACTupleNil.tupleNil ? nil : value];
+      }
 
-			[subscriber sendCompleted];
-		}];
-	}] setNameWithFormat:@"[%@] -takeLast: %lu", self.name, (unsigned long)count];
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -takeLast: %lu", self.name, (unsigned long)count];
 }
 
 - (RACSignal *)combineLatestWith:(RACSignal *)signal {
-	NSCParameterAssert(signal != nil);
+  NSCParameterAssert(signal != nil);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
 
-		__block id lastSelfValue = nil;
-		__block BOOL selfCompleted = NO;
+    __block id lastSelfValue = nil;
+    __block BOOL selfCompleted = NO;
 
-		__block id lastOtherValue = nil;
-		__block BOOL otherCompleted = NO;
+    __block id lastOtherValue = nil;
+    __block BOOL otherCompleted = NO;
 
-		void (^sendNext)(void) = ^{
-			@synchronized (disposable) {
-				if (lastSelfValue == nil || lastOtherValue == nil) return;
-				[subscriber sendNext:RACTuplePack(lastSelfValue, lastOtherValue)];
-			}
-		};
+    void (^sendNext)(void) = ^{
+      @synchronized (disposable) {
+        if (lastSelfValue == nil || lastOtherValue == nil) return;
+        [subscriber sendNext:RACTuplePack(lastSelfValue, lastOtherValue)];
+      }
+    };
 
-		RACDisposable *selfDisposable = [self subscribeNext:^(id x) {
-			@synchronized (disposable) {
-				lastSelfValue = x ?: RACTupleNil.tupleNil;
-				sendNext();
-			}
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			@synchronized (disposable) {
-				selfCompleted = YES;
-				if (otherCompleted) [subscriber sendCompleted];
-			}
-		}];
+    RACDisposable *selfDisposable = [self subscribeNext:^(id x) {
+      @synchronized (disposable) {
+        lastSelfValue = x ?: RACTupleNil.tupleNil;
+        sendNext();
+      }
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      @synchronized (disposable) {
+        selfCompleted = YES;
+        if (otherCompleted) [subscriber sendCompleted];
+      }
+    }];
 
-		[disposable addDisposable:selfDisposable];
+    [disposable addDisposable:selfDisposable];
 
-		RACDisposable *otherDisposable = [signal subscribeNext:^(id x) {
-			@synchronized (disposable) {
-				lastOtherValue = x ?: RACTupleNil.tupleNil;
-				sendNext();
-			}
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			@synchronized (disposable) {
-				otherCompleted = YES;
-				if (selfCompleted) [subscriber sendCompleted];
-			}
-		}];
+    RACDisposable *otherDisposable = [signal subscribeNext:^(id x) {
+      @synchronized (disposable) {
+        lastOtherValue = x ?: RACTupleNil.tupleNil;
+        sendNext();
+      }
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      @synchronized (disposable) {
+        otherCompleted = YES;
+        if (selfCompleted) [subscriber sendCompleted];
+      }
+    }];
 
-		[disposable addDisposable:otherDisposable];
+    [disposable addDisposable:otherDisposable];
 
-		return disposable;
-	}] setNameWithFormat:@"[%@] -combineLatestWith: %@", self.name, signal];
+    return disposable;
+  }] setNameWithFormat:@"[%@] -combineLatestWith: %@", self.name, signal];
 }
 
 + (RACSignal *)combineLatest:(id<NSFastEnumeration>)signals {
-	return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-		NSMutableArray<RACSignal *> *signalsArray = [NSMutableArray array];
-		for (RACSignal *signal in signals) {
-			[signalsArray addObject:signal];
-		}
+  return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+    NSMutableArray<RACSignal *> *signalsArray = [NSMutableArray array];
+    for (RACSignal *signal in signals) {
+      [signalsArray addObject:signal];
+    }
 
-		NSUInteger signalsCount = signalsArray.count;
-		if (!signalsCount) {
-			[subscriber sendCompleted];
-			return nil;
-		}
+    NSUInteger signalsCount = signalsArray.count;
+    if (!signalsCount) {
+      [subscriber sendCompleted];
+      return nil;
+    }
 
-		// Number of signals that completed.
-		__block NSUInteger completedCount = 0;
-		// Set of signal indices that already sent at least one value.
-		__block NSMutableSet<NSNumber *> *sentValues = [NSMutableSet set];
-		// Last value that was sent by each signal.
-		__block NSMutableArray *lastValues = [NSMutableArray arrayWithCapacity:signalsCount];
-		for (NSUInteger i = 0; i < signalsCount; ++i) {
-			[lastValues addObject:[NSNull null]];
-		}
+    // Number of signals that completed.
+    __block NSUInteger completedCount = 0;
+    // Set of signal indices that already sent at least one value.
+    __block NSMutableSet<NSNumber *> *sentValues = [NSMutableSet set];
+    // Last value that was sent by each signal.
+    __block NSMutableArray *lastValues = [NSMutableArray arrayWithCapacity:signalsCount];
+    for (NSUInteger i = 0; i < signalsCount; ++i) {
+      [lastValues addObject:[NSNull null]];
+    }
 
-		void (^sendNext)() = ^() {
-			if (sentValues.count < signalsCount) return;
-			[subscriber sendNext:[RACTuple tupleWithObjectsFromArray:lastValues]];
-		};
+    void (^sendNext)() = ^() {
+      if (sentValues.count < signalsCount) return;
+      [subscriber sendNext:[RACTuple tupleWithObjectsFromArray:lastValues]];
+    };
 
-		RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
+    RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
 
-		for (NSUInteger i = 0; i < signalsArray.count; ++i) {
-			RACDisposable *innerDisposable = [signalsArray[i] subscribeNext:^(id x) {
-				@synchronized (disposable) {
-					[sentValues addObject:@(i)];
-					lastValues[i] = x ?: RACTupleNil.tupleNil;
-					sendNext();
-				}
-			} error:^(NSError *error) {
-				[subscriber sendError:error];
-			} completed:^{
-				@synchronized (disposable) {
-					++completedCount;
-					if (completedCount == signalsCount) {
-						[subscriber sendCompleted];
-					}
-				}
-			}];
+    for (NSUInteger i = 0; i < signalsArray.count; ++i) {
+      RACDisposable *innerDisposable = [signalsArray[i] subscribeNext:^(id x) {
+        @synchronized (disposable) {
+          [sentValues addObject:@(i)];
+          lastValues[i] = x ?: RACTupleNil.tupleNil;
+          sendNext();
+        }
+      } error:^(NSError *error) {
+        [subscriber sendError:error];
+      } completed:^{
+        @synchronized (disposable) {
+          ++completedCount;
+          if (completedCount == signalsCount) {
+            [subscriber sendCompleted];
+          }
+        }
+      }];
 
-			[disposable addDisposable:innerDisposable];
-		}
+      [disposable addDisposable:innerDisposable];
+    }
 
-		return disposable;
-	}] setNameWithFormat:@"+combineLatest: %@", signals];
+    return disposable;
+  }] setNameWithFormat:@"+combineLatest: %@", signals];
 }
 
 + (RACSignal *)combineLatest:(id<NSFastEnumeration>)signals reduce:(id (^)())reduceBlock {
-	NSCParameterAssert(reduceBlock != nil);
+  NSCParameterAssert(reduceBlock != nil);
 
-	RACSignal *result = [self combineLatest:signals];
+  RACSignal *result = [self combineLatest:signals];
 
-	// Although we assert this condition above, older versions of this method
-	// supported this argument being nil. Avoid crashing Release builds of
-	// apps that depended on that.
-	if (reduceBlock != nil) result = [result reduceEach:reduceBlock];
+  // Although we assert this condition above, older versions of this method
+  // supported this argument being nil. Avoid crashing Release builds of
+  // apps that depended on that.
+  if (reduceBlock != nil) result = [result reduceEach:reduceBlock];
 
-	return [result setNameWithFormat:@"+combineLatest: %@ reduce:", signals];
+  return [result setNameWithFormat:@"+combineLatest: %@ reduce:", signals];
 }
 
 - (RACSignal *)merge:(RACSignal *)signal {
-	return [[RACSignal
-		merge:@[ self, signal ]]
-		setNameWithFormat:@"[%@] -merge: %@", self.name, signal];
+  return [[RACSignal
+    merge:@[ self, signal ]]
+    setNameWithFormat:@"[%@] -merge: %@", self.name, signal];
 }
 
 + (RACSignal *)merge:(id<NSFastEnumeration>)signals {
-	NSMutableArray *copiedSignals = [[NSMutableArray alloc] init];
-	for (RACSignal *signal in signals) {
-		[copiedSignals addObject:signal];
-	}
+  NSMutableArray *copiedSignals = [[NSMutableArray alloc] init];
+  for (RACSignal *signal in signals) {
+    [copiedSignals addObject:signal];
+  }
 
-	return [[[RACSignal
-		createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			for (RACSignal *signal in copiedSignals) {
-				[subscriber sendNext:signal];
-			}
+  return [[[RACSignal
+    createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      for (RACSignal *signal in copiedSignals) {
+        [subscriber sendNext:signal];
+      }
 
-			[subscriber sendCompleted];
-			return nil;
-		}]
-		flatten]
-		setNameWithFormat:@"+merge: %@", copiedSignals];
+      [subscriber sendCompleted];
+      return nil;
+    }]
+    flatten]
+    setNameWithFormat:@"+merge: %@", copiedSignals];
 }
 
 - (RACSignal *)flatten:(NSUInteger)maxConcurrent {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACCompoundDisposable *compoundDisposable = [[RACCompoundDisposable alloc] init];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACCompoundDisposable *compoundDisposable = [[RACCompoundDisposable alloc] init];
 
-		// Contains disposables for the currently active subscriptions.
-		//
-		// This should only be used while synchronized on `subscriber`.
-		NSMutableArray *activeDisposables = [[NSMutableArray alloc] initWithCapacity:maxConcurrent];
+    // Contains disposables for the currently active subscriptions.
+    //
+    // This should only be used while synchronized on `subscriber`.
+    NSMutableArray *activeDisposables = [[NSMutableArray alloc] initWithCapacity:maxConcurrent];
 
-		// Whether the signal-of-signals has completed yet.
-		//
-		// This should only be used while synchronized on `subscriber`.
-		__block BOOL selfCompleted = NO;
+    // Whether the signal-of-signals has completed yet.
+    //
+    // This should only be used while synchronized on `subscriber`.
+    __block BOOL selfCompleted = NO;
 
-		// Subscribes to the given signal.
-		__block void (^subscribeToSignal)(RACSignal *);
+    // Subscribes to the given signal.
+    __block void (^subscribeToSignal)(RACSignal *);
 
-		// Weak reference to the above, to avoid a leak.
-		__weak __block void (^recur)(RACSignal *);
+    // Weak reference to the above, to avoid a leak.
+    __weak __block void (^recur)(RACSignal *);
 
-		// Sends completed to the subscriber if all signals are finished.
-		//
-		// This should only be used while synchronized on `subscriber`.
-		void (^completeIfAllowed)(void) = ^{
-			if (selfCompleted && activeDisposables.count == 0) {
-				[subscriber sendCompleted];
-			}
-		};
+    // Sends completed to the subscriber if all signals are finished.
+    //
+    // This should only be used while synchronized on `subscriber`.
+    void (^completeIfAllowed)(void) = ^{
+      if (selfCompleted && activeDisposables.count == 0) {
+        [subscriber sendCompleted];
+      }
+    };
 
-		// The signals waiting to be started.
-		//
-		// This array should only be used while synchronized on `subscriber`.
-		NSMutableArray *queuedSignals = [NSMutableArray array];
+    // The signals waiting to be started.
+    //
+    // This array should only be used while synchronized on `subscriber`.
+    NSMutableArray *queuedSignals = [NSMutableArray array];
 
-		recur = subscribeToSignal = ^(RACSignal *signal) {
-			RACSerialDisposable *serialDisposable = [[RACSerialDisposable alloc] init];
+    recur = subscribeToSignal = ^(RACSignal *signal) {
+      RACSerialDisposable *serialDisposable = [[RACSerialDisposable alloc] init];
 
-			@synchronized (subscriber) {
-				[compoundDisposable addDisposable:serialDisposable];
-				[activeDisposables addObject:serialDisposable];
-			}
+      @synchronized (subscriber) {
+        [compoundDisposable addDisposable:serialDisposable];
+        [activeDisposables addObject:serialDisposable];
+      }
 
-			serialDisposable.disposable = [signal subscribeNext:^(id x) {
-				[subscriber sendNext:x];
-			} error:^(NSError *error) {
-				[subscriber sendError:error];
-			} completed:^{
-				__strong void (^subscribeToSignal)(RACSignal *) = recur;
-				RACSignal *nextSignal;
+      serialDisposable.disposable = [signal subscribeNext:^(id x) {
+        [subscriber sendNext:x];
+      } error:^(NSError *error) {
+        [subscriber sendError:error];
+      } completed:^{
+        __strong void (^subscribeToSignal)(RACSignal *) = recur;
+        RACSignal *nextSignal;
 
-				@synchronized (subscriber) {
-					[compoundDisposable removeDisposable:serialDisposable];
-					[activeDisposables removeObjectIdenticalTo:serialDisposable];
+        @synchronized (subscriber) {
+          [compoundDisposable removeDisposable:serialDisposable];
+          [activeDisposables removeObjectIdenticalTo:serialDisposable];
 
-					if (queuedSignals.count == 0) {
-						completeIfAllowed();
-						return;
-					}
+          if (queuedSignals.count == 0) {
+            completeIfAllowed();
+            return;
+          }
 
-					nextSignal = queuedSignals[0];
-					[queuedSignals removeObjectAtIndex:0];
-				}
+          nextSignal = queuedSignals[0];
+          [queuedSignals removeObjectAtIndex:0];
+        }
 
-				subscribeToSignal(nextSignal);
-			}];
-		};
+        subscribeToSignal(nextSignal);
+      }];
+    };
 
-		[compoundDisposable addDisposable:[self subscribeNext:^(RACSignal *signal) {
-			if (signal == nil) return;
+    [compoundDisposable addDisposable:[self subscribeNext:^(RACSignal *signal) {
+      if (signal == nil) return;
 
-			NSCAssert([signal isKindOfClass:RACSignal.class], @"Expected a RACSignal, got %@", signal);
+      NSCAssert([signal isKindOfClass:RACSignal.class], @"Expected a RACSignal, got %@", signal);
 
-			@synchronized (subscriber) {
-				if (maxConcurrent > 0 && activeDisposables.count >= maxConcurrent) {
-					[queuedSignals addObject:signal];
+      @synchronized (subscriber) {
+        if (maxConcurrent > 0 && activeDisposables.count >= maxConcurrent) {
+          [queuedSignals addObject:signal];
 
-					// If we need to wait, skip subscribing to this
-					// signal.
-					return;
-				}
-			}
+          // If we need to wait, skip subscribing to this
+          // signal.
+          return;
+        }
+      }
 
-			subscribeToSignal(signal);
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			@synchronized (subscriber) {
-				selfCompleted = YES;
-				completeIfAllowed();
-			}
-		}]];
+      subscribeToSignal(signal);
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      @synchronized (subscriber) {
+        selfCompleted = YES;
+        completeIfAllowed();
+      }
+    }]];
 
-		[compoundDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-			// A strong reference is held to `subscribeToSignal` until we're
-			// done, preventing it from deallocating early.
-			subscribeToSignal = nil;
-		}]];
+    [compoundDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+      // A strong reference is held to `subscribeToSignal` until we're
+      // done, preventing it from deallocating early.
+      subscribeToSignal = nil;
+    }]];
 
-		return compoundDisposable;
-	}] setNameWithFormat:@"[%@] -flatten: %lu", self.name, (unsigned long)maxConcurrent];
+    return compoundDisposable;
+  }] setNameWithFormat:@"[%@] -flatten: %lu", self.name, (unsigned long)maxConcurrent];
 }
 
 - (RACSignal *)then:(RACSignal * (^)(void))block {
-	NSCParameterAssert(block != nil);
+  NSCParameterAssert(block != nil);
 
-	return [[[self
-		ignoreValues]
-		concat:[RACSignal defer:block]]
-		setNameWithFormat:@"[%@] -then:", self.name];
+  return [[[self
+    ignoreValues]
+    concat:[RACSignal defer:block]]
+    setNameWithFormat:@"[%@] -then:", self.name];
 }
 
 - (RACSignal *)concat {
-	return [[self flatten:1] setNameWithFormat:@"[%@] -concat", self.name];
+  return [[self flatten:1] setNameWithFormat:@"[%@] -concat", self.name];
 }
 
 - (RACSignal *)aggregateWithStartFactory:(id (^)(void))startFactory reduce:(id (^)(id running, id next))reduceBlock {
-	NSCParameterAssert(startFactory != NULL);
-	NSCParameterAssert(reduceBlock != NULL);
+  NSCParameterAssert(startFactory != NULL);
+  NSCParameterAssert(reduceBlock != NULL);
 
-	return [[RACSignal defer:^{
-		return [self aggregateWithStart:startFactory() reduce:reduceBlock];
-	}] setNameWithFormat:@"[%@] -aggregateWithStartFactory:reduce:", self.name];
+  return [[RACSignal defer:^{
+    return [self aggregateWithStart:startFactory() reduce:reduceBlock];
+  }] setNameWithFormat:@"[%@] -aggregateWithStartFactory:reduce:", self.name];
 }
 
 - (RACSignal *)aggregateWithStart:(id)start reduce:(id (^)(id running, id next))reduceBlock {
-	return [[self
-		aggregateWithStart:start
-		reduceWithIndex:^(id running, id next, NSUInteger index) {
-			return reduceBlock(running, next);
-		}]
-		setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduce:", self.name, RACDescription(start)];
+  return [[self
+    aggregateWithStart:start
+    reduceWithIndex:^(id running, id next, NSUInteger index) {
+      return reduceBlock(running, next);
+    }]
+    setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduce:", self.name, RACDescription(start)];
 }
 
 - (RACSignal *)aggregateWithStart:(id)start reduceWithIndex:(id (^)(id, id, NSUInteger))reduceBlock {
-	return [[[[self
-		scanWithStart:start reduceWithIndex:reduceBlock]
-		startWith:start]
-		takeLast:1]
-		setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduceWithIndex:", self.name, RACDescription(start)];
+  return [[[[self
+    scanWithStart:start reduceWithIndex:reduceBlock]
+    startWith:start]
+    takeLast:1]
+    setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduceWithIndex:", self.name, RACDescription(start)];
 }
 
 - (RACDisposable *)setKeyPath:(NSString *)keyPath onObject:(NSObject *)object {
-	return [self setKeyPath:keyPath onObject:object nilValue:nil];
+  return [self setKeyPath:keyPath onObject:object nilValue:nil];
 }
 
 - (RACDisposable *)setKeyPath:(NSString *)keyPath onObject:(NSObject *)object nilValue:(id)nilValue {
-	NSCParameterAssert(keyPath != nil);
-	NSCParameterAssert(object != nil);
+  NSCParameterAssert(keyPath != nil);
+  NSCParameterAssert(object != nil);
 
-	keyPath = [keyPath copy];
+  keyPath = [keyPath copy];
 
-	RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
+  RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
 
-	// Purposely not retaining 'object', since we want to tear down the binding
-	// when it deallocates normally.
-	__block void * volatile objectPtr = (__bridge void *)object;
+  // Purposely not retaining 'object', since we want to tear down the binding
+  // when it deallocates normally.
+  __block void * volatile objectPtr = (__bridge void *)object;
 
-	RACDisposable *subscriptionDisposable = [self subscribeNext:^(id x) {
-		// Possibly spec, possibly compiler bug, but this __bridge cast does not
-		// result in a retain here, effectively an invisible __unsafe_unretained
-		// qualifier. Using objc_precise_lifetime gives the __strong reference
-		// desired. The explicit use of __strong is strictly defensive.
-		__strong NSObject *object __attribute__((objc_precise_lifetime)) = (__bridge __strong id)objectPtr;
-		[object setValue:x ?: nilValue forKeyPath:keyPath];
-	} error:^(NSError *error) {
-		__strong NSObject *object __attribute__((objc_precise_lifetime)) = (__bridge __strong id)objectPtr;
+  RACDisposable *subscriptionDisposable = [self subscribeNext:^(id x) {
+    // Possibly spec, possibly compiler bug, but this __bridge cast does not
+    // result in a retain here, effectively an invisible __unsafe_unretained
+    // qualifier. Using objc_precise_lifetime gives the __strong reference
+    // desired. The explicit use of __strong is strictly defensive.
+    __strong NSObject *object __attribute__((objc_precise_lifetime)) = (__bridge __strong id)objectPtr;
+    [object setValue:x ?: nilValue forKeyPath:keyPath];
+  } error:^(NSError *error) {
+    __strong NSObject *object __attribute__((objc_precise_lifetime)) = (__bridge __strong id)objectPtr;
 
-		NSCAssert(NO, @"Received error from %@ in binding for key path \"%@\" on %@: %@", self, keyPath, object, error);
+    NSCAssert(NO, @"Received error from %@ in binding for key path \"%@\" on %@: %@", self, keyPath, object, error);
 
-		// Log the error if we're running with assertions disabled.
-		NSLog(@"Received error from %@ in binding for key path \"%@\" on %@: %@", self, keyPath, object, error);
+    // Log the error if we're running with assertions disabled.
+    NSLog(@"Received error from %@ in binding for key path \"%@\" on %@: %@", self, keyPath, object, error);
 
-		[disposable dispose];
-	} completed:^{
-		[disposable dispose];
-	}];
+    [disposable dispose];
+  } completed:^{
+    [disposable dispose];
+  }];
 
-	[disposable addDisposable:subscriptionDisposable];
+  [disposable addDisposable:subscriptionDisposable];
 
-	#if DEBUG
-	static void *bindingsKey = &bindingsKey;
-	NSMutableDictionary *bindings;
+  #if DEBUG
+  static void *bindingsKey = &bindingsKey;
+  NSMutableDictionary *bindings;
 
-	@synchronized (object) {
-		bindings = objc_getAssociatedObject(object, bindingsKey);
-		if (bindings == nil) {
-			bindings = [NSMutableDictionary dictionary];
-			objc_setAssociatedObject(object, bindingsKey, bindings, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-		}
-	}
+  @synchronized (object) {
+    bindings = objc_getAssociatedObject(object, bindingsKey);
+    if (bindings == nil) {
+      bindings = [NSMutableDictionary dictionary];
+      objc_setAssociatedObject(object, bindingsKey, bindings, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+  }
 
-	@synchronized (bindings) {
-		NSCAssert(bindings[keyPath] == nil, @"Signal %@ is already bound to key path \"%@\" on object %@, adding signal %@ is undefined behavior", [bindings[keyPath] nonretainedObjectValue], keyPath, object, self);
+  @synchronized (bindings) {
+    NSCAssert(bindings[keyPath] == nil, @"Signal %@ is already bound to key path \"%@\" on object %@, adding signal %@ is undefined behavior", [bindings[keyPath] nonretainedObjectValue], keyPath, object, self);
 
-		bindings[keyPath] = [NSValue valueWithNonretainedObject:self];
-	}
-	#endif
+    bindings[keyPath] = [NSValue valueWithNonretainedObject:self];
+  }
+  #endif
 
-	RACDisposable *clearPointerDisposable = [RACDisposable disposableWithBlock:^{
-		#if DEBUG
-		@synchronized (bindings) {
-			[bindings removeObjectForKey:keyPath];
-		}
-		#endif
+  RACDisposable *clearPointerDisposable = [RACDisposable disposableWithBlock:^{
+    #if DEBUG
+    @synchronized (bindings) {
+      [bindings removeObjectForKey:keyPath];
+    }
+    #endif
 
-		while (YES) {
-			void *ptr = objectPtr;
-			if (OSAtomicCompareAndSwapPtrBarrier(ptr, NULL, &objectPtr)) {
-				break;
-			}
-		}
-	}];
+    while (YES) {
+      void *ptr = objectPtr;
+      if (OSAtomicCompareAndSwapPtrBarrier(ptr, NULL, &objectPtr)) {
+        break;
+      }
+    }
+  }];
 
-	[disposable addDisposable:clearPointerDisposable];
+  [disposable addDisposable:clearPointerDisposable];
 
-	[object.rac_deallocDisposable addDisposable:disposable];
+  [object.rac_deallocDisposable addDisposable:disposable];
 
-	RACCompoundDisposable *objectDisposable = object.rac_deallocDisposable;
-	return [RACDisposable disposableWithBlock:^{
-		[objectDisposable removeDisposable:disposable];
-		[disposable dispose];
-	}];
+  RACCompoundDisposable *objectDisposable = object.rac_deallocDisposable;
+  return [RACDisposable disposableWithBlock:^{
+    [objectDisposable removeDisposable:disposable];
+    [disposable dispose];
+  }];
 }
 
 + (RACSignal *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler {
-	return [[RACSignal interval:interval onScheduler:scheduler withLeeway:0.0] setNameWithFormat:@"+interval: %f onScheduler: %@", (double)interval, scheduler];
+  return [[RACSignal interval:interval onScheduler:scheduler withLeeway:0.0] setNameWithFormat:@"+interval: %f onScheduler: %@", (double)interval, scheduler];
 }
 
 + (RACSignal *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler withLeeway:(NSTimeInterval)leeway {
-	NSCParameterAssert(scheduler != nil);
-	NSCParameterAssert(scheduler != RACScheduler.immediateScheduler);
+  NSCParameterAssert(scheduler != nil);
+  NSCParameterAssert(scheduler != RACScheduler.immediateScheduler);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		return [scheduler after:[NSDate dateWithTimeIntervalSinceNow:interval] repeatingEvery:interval withLeeway:leeway schedule:^{
-			[subscriber sendNext:[NSDate date]];
-		}];
-	}] setNameWithFormat:@"+interval: %f onScheduler: %@ withLeeway: %f", (double)interval, scheduler, (double)leeway];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    return [scheduler after:[NSDate dateWithTimeIntervalSinceNow:interval] repeatingEvery:interval withLeeway:leeway schedule:^{
+      [subscriber sendNext:[NSDate date]];
+    }];
+  }] setNameWithFormat:@"+interval: %f onScheduler: %@ withLeeway: %f", (double)interval, scheduler, (double)leeway];
 }
 
 - (RACSignal *)takeUntil:(RACSignal *)signalTrigger {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
-		void (^triggerCompletion)(void) = ^{
-			[disposable dispose];
-			[subscriber sendCompleted];
-		};
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
+    void (^triggerCompletion)(void) = ^{
+      [disposable dispose];
+      [subscriber sendCompleted];
+    };
 
-		RACDisposable *triggerDisposable = [signalTrigger subscribeNext:^(id _) {
-			triggerCompletion();
-		} completed:^{
-			triggerCompletion();
-		}];
+    RACDisposable *triggerDisposable = [signalTrigger subscribeNext:^(id _) {
+      triggerCompletion();
+    } completed:^{
+      triggerCompletion();
+    }];
 
-		[disposable addDisposable:triggerDisposable];
+    [disposable addDisposable:triggerDisposable];
 
-		if (!disposable.disposed) {
-			RACDisposable *selfDisposable = [self subscribeNext:^(id x) {
-				[subscriber sendNext:x];
-			} error:^(NSError *error) {
-				[subscriber sendError:error];
-			} completed:^{
-				[disposable dispose];
-				[subscriber sendCompleted];
-			}];
+    if (!disposable.disposed) {
+      RACDisposable *selfDisposable = [self subscribeNext:^(id x) {
+        [subscriber sendNext:x];
+      } error:^(NSError *error) {
+        [subscriber sendError:error];
+      } completed:^{
+        [disposable dispose];
+        [subscriber sendCompleted];
+      }];
 
-			[disposable addDisposable:selfDisposable];
-		}
+      [disposable addDisposable:selfDisposable];
+    }
 
-		return disposable;
-	}] setNameWithFormat:@"[%@] -takeUntil: %@", self.name, signalTrigger];
+    return disposable;
+  }] setNameWithFormat:@"[%@] -takeUntil: %@", self.name, signalTrigger];
 }
 
 - (RACSignal *)takeUntilReplacement:(RACSignal *)replacement {
-	return [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACSerialDisposable *selfDisposable = [[RACSerialDisposable alloc] init];
+  return [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACSerialDisposable *selfDisposable = [[RACSerialDisposable alloc] init];
 
-		RACDisposable *replacementDisposable = [replacement subscribeNext:^(id x) {
-			[selfDisposable dispose];
-			[subscriber sendNext:x];
-		} error:^(NSError *error) {
-			[selfDisposable dispose];
-			[subscriber sendError:error];
-		} completed:^{
-			[selfDisposable dispose];
-			[subscriber sendCompleted];
-		}];
+    RACDisposable *replacementDisposable = [replacement subscribeNext:^(id x) {
+      [selfDisposable dispose];
+      [subscriber sendNext:x];
+    } error:^(NSError *error) {
+      [selfDisposable dispose];
+      [subscriber sendError:error];
+    } completed:^{
+      [selfDisposable dispose];
+      [subscriber sendCompleted];
+    }];
 
-		if (!selfDisposable.disposed) {
-			selfDisposable.disposable = [[self
-				concat:[RACSignal never]]
-				subscribe:subscriber];
-		}
+    if (!selfDisposable.disposed) {
+      selfDisposable.disposable = [[self
+        concat:[RACSignal never]]
+        subscribe:subscriber];
+    }
 
-		return [RACDisposable disposableWithBlock:^{
-			[selfDisposable dispose];
-			[replacementDisposable dispose];
-		}];
-	}];
+    return [RACDisposable disposableWithBlock:^{
+      [selfDisposable dispose];
+      [replacementDisposable dispose];
+    }];
+  }];
 }
 
 - (RACSignal *)switchToLatest {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACMulticastConnection *connection = [self publish];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACMulticastConnection *connection = [self publish];
 
-		RACDisposable *subscriptionDisposable = [[connection.signal
-			flattenMap:^(RACSignal *x) {
-				NSCAssert(x == nil || [x isKindOfClass:RACSignal.class], @"-switchToLatest requires that the source signal (%@) send signals. Instead we got: %@", self, x);
+    RACDisposable *subscriptionDisposable = [[connection.signal
+      flattenMap:^(RACSignal *x) {
+        NSCAssert(x == nil || [x isKindOfClass:RACSignal.class], @"-switchToLatest requires that the source signal (%@) send signals. Instead we got: %@", self, x);
 
-				// -concat:[RACSignal never] prevents completion of the receiver from
-				// prematurely terminating the inner signal.
-				return [x takeUntil:[connection.signal concat:[RACSignal never]]];
-			}]
-			subscribe:subscriber];
+        // -concat:[RACSignal never] prevents completion of the receiver from
+        // prematurely terminating the inner signal.
+        return [x takeUntil:[connection.signal concat:[RACSignal never]]];
+      }]
+      subscribe:subscriber];
 
-		RACDisposable *connectionDisposable = [connection connect];
-		return [RACDisposable disposableWithBlock:^{
-			[subscriptionDisposable dispose];
-			[connectionDisposable dispose];
-		}];
-	}] setNameWithFormat:@"[%@] -switchToLatest", self.name];
+    RACDisposable *connectionDisposable = [connection connect];
+    return [RACDisposable disposableWithBlock:^{
+      [subscriptionDisposable dispose];
+      [connectionDisposable dispose];
+    }];
+  }] setNameWithFormat:@"[%@] -switchToLatest", self.name];
 }
 
 + (RACSignal *)switch:(RACSignal *)signal cases:(NSDictionary *)cases default:(RACSignal *)defaultSignal {
-	NSCParameterAssert(signal != nil);
-	NSCParameterAssert(cases != nil);
+  NSCParameterAssert(signal != nil);
+  NSCParameterAssert(cases != nil);
 
-	for (id key in cases) {
-		id value __attribute__((unused)) = cases[key];
-		NSCAssert([value isKindOfClass:RACSignal.class], @"Expected all cases to be RACSignals, %@ isn't", value);
-	}
+  for (id key in cases) {
+    id value __attribute__((unused)) = cases[key];
+    NSCAssert([value isKindOfClass:RACSignal.class], @"Expected all cases to be RACSignals, %@ isn't", value);
+  }
 
-	NSDictionary *copy = [cases copy];
+  NSDictionary *copy = [cases copy];
 
-	return [[[signal
-		map:^(id key) {
-			if (key == nil) key = RACTupleNil.tupleNil;
+  return [[[signal
+    map:^(id key) {
+      if (key == nil) key = RACTupleNil.tupleNil;
 
-			RACSignal *signal = copy[key] ?: defaultSignal;
-			if (signal == nil) {
-				NSString *description = [NSString stringWithFormat:NSLocalizedString(@"No matching signal found for value %@", @""), key];
-				return [RACSignal error:[NSError errorWithDomain:RACSignalErrorDomain code:RACSignalErrorNoMatchingCase userInfo:@{ NSLocalizedDescriptionKey: description }]];
-			}
+      RACSignal *signal = copy[key] ?: defaultSignal;
+      if (signal == nil) {
+        NSString *description = [NSString stringWithFormat:NSLocalizedString(@"No matching signal found for value %@", @""), key];
+        return [RACSignal error:[NSError errorWithDomain:RACSignalErrorDomain code:RACSignalErrorNoMatchingCase userInfo:@{ NSLocalizedDescriptionKey: description }]];
+      }
 
-			return signal;
-		}]
-		switchToLatest]
-		setNameWithFormat:@"+switch: %@ cases: %@ default: %@", signal, cases, defaultSignal];
+      return signal;
+    }]
+    switchToLatest]
+    setNameWithFormat:@"+switch: %@ cases: %@ default: %@", signal, cases, defaultSignal];
 }
 
 + (RACSignal *)if:(RACSignal *)boolSignal then:(RACSignal *)trueSignal else:(RACSignal *)falseSignal {
-	NSCParameterAssert(boolSignal != nil);
-	NSCParameterAssert(trueSignal != nil);
-	NSCParameterAssert(falseSignal != nil);
+  NSCParameterAssert(boolSignal != nil);
+  NSCParameterAssert(trueSignal != nil);
+  NSCParameterAssert(falseSignal != nil);
 
-	return [[[boolSignal
-		map:^(NSNumber *value) {
-			NSCAssert([value isKindOfClass:NSNumber.class], @"Expected %@ to send BOOLs, not %@", boolSignal, value);
+  return [[[boolSignal
+    map:^(NSNumber *value) {
+      NSCAssert([value isKindOfClass:NSNumber.class], @"Expected %@ to send BOOLs, not %@", boolSignal, value);
 
-			return (value.boolValue ? trueSignal : falseSignal);
-		}]
-		switchToLatest]
-		setNameWithFormat:@"+if: %@ then: %@ else: %@", boolSignal, trueSignal, falseSignal];
+      return (value.boolValue ? trueSignal : falseSignal);
+    }]
+    switchToLatest]
+    setNameWithFormat:@"+if: %@ then: %@ else: %@", boolSignal, trueSignal, falseSignal];
 }
 
 - (id)first {
-	return [self firstOrDefault:nil];
+  return [self firstOrDefault:nil];
 }
 
 - (id)firstOrDefault:(id)defaultValue {
-	return [self firstOrDefault:defaultValue success:NULL error:NULL];
+  return [self firstOrDefault:defaultValue success:NULL error:NULL];
 }
 
 - (id)firstOrDefault:(id)defaultValue success:(BOOL *)success error:(NSError **)error {
-	NSCondition *condition = [[NSCondition alloc] init];
-	condition.name = [NSString stringWithFormat:@"[%@] -firstOrDefault: %@ success:error:", self.name, defaultValue];
+  NSCondition *condition = [[NSCondition alloc] init];
+  condition.name = [NSString stringWithFormat:@"[%@] -firstOrDefault: %@ success:error:", self.name, defaultValue];
 
-	__block id value = defaultValue;
-	__block BOOL done = NO;
+  __block id value = defaultValue;
+  __block BOOL done = NO;
 
-	// Ensures that we don't pass values across thread boundaries by reference.
-	__block NSError *localError;
-	__block BOOL localSuccess;
+  // Ensures that we don't pass values across thread boundaries by reference.
+  __block NSError *localError;
+  __block BOOL localSuccess;
 
-	[[self take:1] subscribeNext:^(id x) {
-		[condition lock];
+  [[self take:1] subscribeNext:^(id x) {
+    [condition lock];
 
-		value = x;
-		localSuccess = YES;
+    value = x;
+    localSuccess = YES;
 
-		done = YES;
-		[condition broadcast];
-		[condition unlock];
-	} error:^(NSError *e) {
-		[condition lock];
+    done = YES;
+    [condition broadcast];
+    [condition unlock];
+  } error:^(NSError *e) {
+    [condition lock];
 
-		if (!done) {
-			localSuccess = NO;
-			localError = e;
+    if (!done) {
+      localSuccess = NO;
+      localError = e;
 
-			done = YES;
-			[condition broadcast];
-		}
+      done = YES;
+      [condition broadcast];
+    }
 
-		[condition unlock];
-	} completed:^{
-		[condition lock];
+    [condition unlock];
+  } completed:^{
+    [condition lock];
 
-		localSuccess = YES;
+    localSuccess = YES;
 
-		done = YES;
-		[condition broadcast];
-		[condition unlock];
-	}];
+    done = YES;
+    [condition broadcast];
+    [condition unlock];
+  }];
 
-	[condition lock];
-	while (!done) {
-		[condition wait];
-	}
+  [condition lock];
+  while (!done) {
+    [condition wait];
+  }
 
-	if (success != NULL) *success = localSuccess;
-	if (error != NULL) *error = localError;
+  if (success != NULL) *success = localSuccess;
+  if (error != NULL) *error = localError;
 
-	[condition unlock];
-	return value;
+  [condition unlock];
+  return value;
 }
 
 - (BOOL)waitUntilCompleted:(NSError **)error {
-	BOOL success = NO;
+  BOOL success = NO;
 
-	[[[self
-		ignoreValues]
-		setNameWithFormat:@"[%@] -waitUntilCompleted:", self.name]
-		firstOrDefault:nil success:&success error:error];
+  [[[self
+    ignoreValues]
+    setNameWithFormat:@"[%@] -waitUntilCompleted:", self.name]
+    firstOrDefault:nil success:&success error:error];
 
-	return success;
+  return success;
 }
 
 + (RACSignal *)defer:(RACSignal<id> * (^)(void))block {
-	NSCParameterAssert(block != NULL);
+  NSCParameterAssert(block != NULL);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		return [block() subscribe:subscriber];
-	}] setNameWithFormat:@"+defer:"];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    return [block() subscribe:subscriber];
+  }] setNameWithFormat:@"+defer:"];
 }
 
 - (NSArray *)toArray {
-	return [[[self collect] first] copy];
+  return [[[self collect] first] copy];
 }
 
 - (RACSequence *)sequence {
-	return [[RACSignalSequence sequenceWithSignal:self] setNameWithFormat:@"[%@] -sequence", self.name];
+  return [[RACSignalSequence sequenceWithSignal:self] setNameWithFormat:@"[%@] -sequence", self.name];
 }
 
 - (RACMulticastConnection *)publish {
-	RACSubject *subject = [[RACSubject subject] setNameWithFormat:@"[%@] -publish", self.name];
-	RACMulticastConnection *connection = [self multicast:subject];
-	return connection;
+  RACSubject *subject = [[RACSubject subject] setNameWithFormat:@"[%@] -publish", self.name];
+  RACMulticastConnection *connection = [self multicast:subject];
+  return connection;
 }
 
 - (RACMulticastConnection *)multicast:(RACSubject *)subject {
-	[subject setNameWithFormat:@"[%@] -multicast: %@", self.name, subject.name];
-	RACMulticastConnection *connection = [[RACMulticastConnection alloc] initWithSourceSignal:self subject:subject];
-	return connection;
+  [subject setNameWithFormat:@"[%@] -multicast: %@", self.name, subject.name];
+  RACMulticastConnection *connection = [[RACMulticastConnection alloc] initWithSourceSignal:self subject:subject];
+  return connection;
 }
 
 - (RACSignal *)replay {
-	RACReplaySubject *subject = [[RACReplaySubject subject] setNameWithFormat:@"[%@] -replay", self.name];
+  RACReplaySubject *subject = [[RACReplaySubject subject] setNameWithFormat:@"[%@] -replay", self.name];
 
-	RACMulticastConnection *connection = [self multicast:subject];
-	[connection connect];
+  RACMulticastConnection *connection = [self multicast:subject];
+  [connection connect];
 
-	return connection.signal;
+  return connection.signal;
 }
 
 - (RACSignal *)replayLast {
-	RACReplaySubject *subject = [[RACReplaySubject replaySubjectWithCapacity:1] setNameWithFormat:@"[%@] -replayLast", self.name];
+  RACReplaySubject *subject = [[RACReplaySubject replaySubjectWithCapacity:1] setNameWithFormat:@"[%@] -replayLast", self.name];
 
-	RACMulticastConnection *connection = [self multicast:subject];
-	[connection connect];
+  RACMulticastConnection *connection = [self multicast:subject];
+  [connection connect];
 
-	return connection.signal;
+  return connection.signal;
 }
 
 - (RACSignal *)replayLazily {
-	RACMulticastConnection *connection = [self multicast:[RACReplaySubject subject]];
-	return [[RACSignal
-		defer:^{
-			[connection connect];
-			return connection.signal;
-		}]
-		setNameWithFormat:@"[%@] -replayLazily", self.name];
+  RACMulticastConnection *connection = [self multicast:[RACReplaySubject subject]];
+  return [[RACSignal
+    defer:^{
+      [connection connect];
+      return connection.signal;
+    }]
+    setNameWithFormat:@"[%@] -replayLazily", self.name];
 }
 
 - (RACSignal *)timeout:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler {
-	NSCParameterAssert(scheduler != nil);
-	NSCParameterAssert(scheduler != RACScheduler.immediateScheduler);
+  NSCParameterAssert(scheduler != nil);
+  NSCParameterAssert(scheduler != RACScheduler.immediateScheduler);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
 
-		RACDisposable *timeoutDisposable = [scheduler afterDelay:interval schedule:^{
-			[disposable dispose];
-			[subscriber sendError:[NSError errorWithDomain:RACSignalErrorDomain code:RACSignalErrorTimedOut userInfo:nil]];
-		}];
+    RACDisposable *timeoutDisposable = [scheduler afterDelay:interval schedule:^{
+      [disposable dispose];
+      [subscriber sendError:[NSError errorWithDomain:RACSignalErrorDomain code:RACSignalErrorTimedOut userInfo:nil]];
+    }];
 
-		[disposable addDisposable:timeoutDisposable];
+    [disposable addDisposable:timeoutDisposable];
 
-		RACDisposable *subscriptionDisposable = [self subscribeNext:^(id x) {
-			[subscriber sendNext:x];
-		} error:^(NSError *error) {
-			[disposable dispose];
-			[subscriber sendError:error];
-		} completed:^{
-			[disposable dispose];
-			[subscriber sendCompleted];
-		}];
+    RACDisposable *subscriptionDisposable = [self subscribeNext:^(id x) {
+      [subscriber sendNext:x];
+    } error:^(NSError *error) {
+      [disposable dispose];
+      [subscriber sendError:error];
+    } completed:^{
+      [disposable dispose];
+      [subscriber sendCompleted];
+    }];
 
-		[disposable addDisposable:subscriptionDisposable];
-		return disposable;
-	}] setNameWithFormat:@"[%@] -timeout: %f onScheduler: %@", self.name, (double)interval, scheduler];
+    [disposable addDisposable:subscriptionDisposable];
+    return disposable;
+  }] setNameWithFormat:@"[%@] -timeout: %f onScheduler: %@", self.name, (double)interval, scheduler];
 }
 
 - (RACSignal *)deliverOn:(RACScheduler *)scheduler {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		return [self subscribeNext:^(id x) {
-			[scheduler schedule:^{
-				[subscriber sendNext:x];
-			}];
-		} error:^(NSError *error) {
-			[scheduler schedule:^{
-				[subscriber sendError:error];
-			}];
-		} completed:^{
-			[scheduler schedule:^{
-				[subscriber sendCompleted];
-			}];
-		}];
-	}] setNameWithFormat:@"[%@] -deliverOn: %@", self.name, scheduler];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    return [self subscribeNext:^(id x) {
+      [scheduler schedule:^{
+        [subscriber sendNext:x];
+      }];
+    } error:^(NSError *error) {
+      [scheduler schedule:^{
+        [subscriber sendError:error];
+      }];
+    } completed:^{
+      [scheduler schedule:^{
+        [subscriber sendCompleted];
+      }];
+    }];
+  }] setNameWithFormat:@"[%@] -deliverOn: %@", self.name, scheduler];
 }
 
 - (RACSignal *)subscribeOn:(RACScheduler *)scheduler {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
 
-		RACDisposable *schedulingDisposable = [scheduler schedule:^{
-			RACDisposable *subscriptionDisposable = [self subscribe:subscriber];
+    RACDisposable *schedulingDisposable = [scheduler schedule:^{
+      RACDisposable *subscriptionDisposable = [self subscribe:subscriber];
 
-			[disposable addDisposable:subscriptionDisposable];
-		}];
+      [disposable addDisposable:subscriptionDisposable];
+    }];
 
-		[disposable addDisposable:schedulingDisposable];
-		return disposable;
-	}] setNameWithFormat:@"[%@] -subscribeOn: %@", self.name, scheduler];
+    [disposable addDisposable:schedulingDisposable];
+    return disposable;
+  }] setNameWithFormat:@"[%@] -subscribeOn: %@", self.name, scheduler];
 }
 
 - (RACSignal *)deliverOnMainThread {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		__block volatile int32_t queueLength = 0;
-		
-		void (^performOnMainThread)(dispatch_block_t) = ^(dispatch_block_t block) {
-			int32_t queued = OSAtomicIncrement32(&queueLength);
-			if (NSThread.isMainThread && queued == 1) {
-				block();
-				OSAtomicDecrement32(&queueLength);
-			} else {
-				dispatch_async(dispatch_get_main_queue(), ^{
-					block();
-					OSAtomicDecrement32(&queueLength);
-				});
-			}
-		};
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    __block volatile int32_t queueLength = 0;
+    
+    void (^performOnMainThread)(dispatch_block_t) = ^(dispatch_block_t block) {
+      int32_t queued = OSAtomicIncrement32(&queueLength);
+      if (NSThread.isMainThread && queued == 1) {
+        block();
+        OSAtomicDecrement32(&queueLength);
+      } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+          block();
+          OSAtomicDecrement32(&queueLength);
+        });
+      }
+    };
 
-		return [self subscribeNext:^(id x) {
-			performOnMainThread(^{
-				[subscriber sendNext:x];
-			});
-		} error:^(NSError *error) {
-			performOnMainThread(^{
-				[subscriber sendError:error];
-			});
-		} completed:^{
-			performOnMainThread(^{
-				[subscriber sendCompleted];
-			});
-		}];
-	}] setNameWithFormat:@"[%@] -deliverOnMainThread", self.name];
+    return [self subscribeNext:^(id x) {
+      performOnMainThread(^{
+        [subscriber sendNext:x];
+      });
+    } error:^(NSError *error) {
+      performOnMainThread(^{
+        [subscriber sendError:error];
+      });
+    } completed:^{
+      performOnMainThread(^{
+        [subscriber sendCompleted];
+      });
+    }];
+  }] setNameWithFormat:@"[%@] -deliverOnMainThread", self.name];
 }
 
 - (RACSignal *)groupBy:(id<NSCopying> (^)(id object))keyBlock transform:(id (^)(id object))transformBlock {
-	NSCParameterAssert(keyBlock != NULL);
+  NSCParameterAssert(keyBlock != NULL);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		NSMutableDictionary *groups = [NSMutableDictionary dictionary];
-		NSMutableArray *orderedGroups = [NSMutableArray array];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    NSMutableDictionary *groups = [NSMutableDictionary dictionary];
+    NSMutableArray *orderedGroups = [NSMutableArray array];
 
-		return [self subscribeNext:^(id x) {
-			id<NSCopying> key = keyBlock(x);
-			RACGroupedSignal *groupSubject = nil;
-			@synchronized(groups) {
-				groupSubject = groups[key];
-				if (groupSubject == nil) {
-					groupSubject = [RACGroupedSignal signalWithKey:key];
-					groups[key] = groupSubject;
-					[orderedGroups addObject:groupSubject];
-					[subscriber sendNext:groupSubject];
-				}
-			}
+    return [self subscribeNext:^(id x) {
+      id<NSCopying> key = keyBlock(x);
+      RACGroupedSignal *groupSubject = nil;
+      @synchronized(groups) {
+        groupSubject = groups[key];
+        if (groupSubject == nil) {
+          groupSubject = [RACGroupedSignal signalWithKey:key];
+          groups[key] = groupSubject;
+          [orderedGroups addObject:groupSubject];
+          [subscriber sendNext:groupSubject];
+        }
+      }
 
-			[groupSubject sendNext:transformBlock != NULL ? transformBlock(x) : x];
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
+      [groupSubject sendNext:transformBlock != NULL ? transformBlock(x) : x];
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
 
-			[orderedGroups makeObjectsPerformSelector:@selector(sendError:) withObject:error];
-		} completed:^{
-			[subscriber sendCompleted];
+      [orderedGroups makeObjectsPerformSelector:@selector(sendError:) withObject:error];
+    } completed:^{
+      [subscriber sendCompleted];
 
-			[orderedGroups makeObjectsPerformSelector:@selector(sendCompleted)];
-		}];
-	}] setNameWithFormat:@"[%@] -groupBy:transform:", self.name];
+      [orderedGroups makeObjectsPerformSelector:@selector(sendCompleted)];
+    }];
+  }] setNameWithFormat:@"[%@] -groupBy:transform:", self.name];
 }
 
 - (RACSignal *)groupBy:(id<NSCopying> (^)(id object))keyBlock {
-	return [[self groupBy:keyBlock transform:nil] setNameWithFormat:@"[%@] -groupBy:", self.name];
+  return [[self groupBy:keyBlock transform:nil] setNameWithFormat:@"[%@] -groupBy:", self.name];
 }
 
 - (RACSignal *)any {
-	return [[self any:^(id x) {
-		return YES;
-	}] setNameWithFormat:@"[%@] -any", self.name];
+  return [[self any:^(id x) {
+    return YES;
+  }] setNameWithFormat:@"[%@] -any", self.name];
 }
 
 - (RACSignal *)any:(BOOL (^)(id object))predicateBlock {
-	NSCParameterAssert(predicateBlock != NULL);
+  NSCParameterAssert(predicateBlock != NULL);
 
-	return [[[self materialize] bind:^{
-		return ^(RACEvent *event, BOOL *stop) {
-			if (event.finished) {
-				*stop = YES;
-				return [RACSignal return:@NO];
-			}
+  return [[[self materialize] bind:^{
+    return ^(RACEvent *event, BOOL *stop) {
+      if (event.finished) {
+        *stop = YES;
+        return [RACSignal return:@NO];
+      }
 
-			if (predicateBlock(event.value)) {
-				*stop = YES;
-				return [RACSignal return:@YES];
-			}
+      if (predicateBlock(event.value)) {
+        *stop = YES;
+        return [RACSignal return:@YES];
+      }
 
-			return [RACSignal empty];
-		};
-	}] setNameWithFormat:@"[%@] -any:", self.name];
+      return [RACSignal empty];
+    };
+  }] setNameWithFormat:@"[%@] -any:", self.name];
 }
 
 - (RACSignal *)all:(BOOL (^)(id object))predicateBlock {
-	NSCParameterAssert(predicateBlock != NULL);
+  NSCParameterAssert(predicateBlock != NULL);
 
-	return [[[self materialize] bind:^{
-		return ^(RACEvent *event, BOOL *stop) {
-			if (event.eventType == RACEventTypeCompleted) {
-				*stop = YES;
-				return [RACSignal return:@YES];
-			}
+  return [[[self materialize] bind:^{
+    return ^(RACEvent *event, BOOL *stop) {
+      if (event.eventType == RACEventTypeCompleted) {
+        *stop = YES;
+        return [RACSignal return:@YES];
+      }
 
-			if (event.eventType == RACEventTypeError || !predicateBlock(event.value)) {
-				*stop = YES;
-				return [RACSignal return:@NO];
-			}
+      if (event.eventType == RACEventTypeError || !predicateBlock(event.value)) {
+        *stop = YES;
+        return [RACSignal return:@NO];
+      }
 
-			return [RACSignal empty];
-		};
-	}] setNameWithFormat:@"[%@] -all:", self.name];
+      return [RACSignal empty];
+    };
+  }] setNameWithFormat:@"[%@] -all:", self.name];
 }
 
 - (RACSignal *)retry:(NSInteger)retryCount {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		__block NSInteger currentRetryCount = 0;
-		return subscribeForever(self,
-			^(id x) {
-				[subscriber sendNext:x];
-			},
-			^(NSError *error, RACDisposable *disposable) {
-				if (retryCount == 0 || currentRetryCount < retryCount) {
-					// Resubscribe.
-					currentRetryCount++;
-					return;
-				}
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    __block NSInteger currentRetryCount = 0;
+    return subscribeForever(self,
+      ^(id x) {
+        [subscriber sendNext:x];
+      },
+      ^(NSError *error, RACDisposable *disposable) {
+        if (retryCount == 0 || currentRetryCount < retryCount) {
+          // Resubscribe.
+          currentRetryCount++;
+          return;
+        }
 
-				[disposable dispose];
-				[subscriber sendError:error];
-			},
-			^(RACDisposable *disposable) {
-				[disposable dispose];
-				[subscriber sendCompleted];
-			});
-	}] setNameWithFormat:@"[%@] -retry: %lu", self.name, (unsigned long)retryCount];
+        [disposable dispose];
+        [subscriber sendError:error];
+      },
+      ^(RACDisposable *disposable) {
+        [disposable dispose];
+        [subscriber sendCompleted];
+      });
+  }] setNameWithFormat:@"[%@] -retry: %lu", self.name, (unsigned long)retryCount];
 }
 
 - (RACSignal *)retry {
-	return [[self retry:0] setNameWithFormat:@"[%@] -retry", self.name];
+  return [[self retry:0] setNameWithFormat:@"[%@] -retry", self.name];
 }
 
 - (RACSignal *)sample:(RACSignal *)sampler {
-	NSCParameterAssert(sampler != nil);
+  NSCParameterAssert(sampler != nil);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		NSLock *lock = [[NSLock alloc] init];
-		__block id lastValue;
-		__block BOOL hasValue = NO;
-		__block BOOL selfCompleted = NO;
-		__block BOOL samplerCompleted = NO;
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    NSLock *lock = [[NSLock alloc] init];
+    __block id lastValue;
+    __block BOOL hasValue = NO;
+    __block BOOL selfCompleted = NO;
+    __block BOOL samplerCompleted = NO;
 
-		RACSerialDisposable *samplerDisposable = [[RACSerialDisposable alloc] init];
-		RACDisposable *sourceDisposable = [self subscribeNext:^(id x) {
-			[lock lock];
-			hasValue = YES;
-			lastValue = x;
-			[lock unlock];
-		} error:^(NSError *error) {
-			[samplerDisposable dispose];
-			[subscriber sendError:error];
-		} completed:^{
-			BOOL shouldComplete = NO;
-			[lock lock];
-			selfCompleted = YES;
-			shouldComplete = samplerCompleted;
-			[lock unlock];
+    RACSerialDisposable *samplerDisposable = [[RACSerialDisposable alloc] init];
+    RACDisposable *sourceDisposable = [self subscribeNext:^(id x) {
+      [lock lock];
+      hasValue = YES;
+      lastValue = x;
+      [lock unlock];
+    } error:^(NSError *error) {
+      [samplerDisposable dispose];
+      [subscriber sendError:error];
+    } completed:^{
+      BOOL shouldComplete = NO;
+      [lock lock];
+      selfCompleted = YES;
+      shouldComplete = samplerCompleted;
+      [lock unlock];
 
-			if (shouldComplete) {
-				[samplerDisposable dispose];
-				[subscriber sendCompleted];
-			}
-		}];
+      if (shouldComplete) {
+        [samplerDisposable dispose];
+        [subscriber sendCompleted];
+      }
+    }];
 
-		samplerDisposable.disposable = [sampler subscribeNext:^(id _) {
-			BOOL shouldSend = NO;
-			id value;
-			[lock lock];
-			shouldSend = hasValue;
-			value = lastValue;
-			[lock unlock];
+    samplerDisposable.disposable = [sampler subscribeNext:^(id _) {
+      BOOL shouldSend = NO;
+      id value;
+      [lock lock];
+      shouldSend = hasValue;
+      value = lastValue;
+      [lock unlock];
 
-			if (shouldSend) {
-				[subscriber sendNext:value];
-			}
-		} error:^(NSError *error) {
-			[sourceDisposable dispose];
-			[subscriber sendError:error];
-		} completed:^{
-			BOOL shouldComplete = NO;
-			[lock lock];
-			samplerCompleted = YES;
-			shouldComplete = selfCompleted;
-			[lock unlock];
+      if (shouldSend) {
+        [subscriber sendNext:value];
+      }
+    } error:^(NSError *error) {
+      [sourceDisposable dispose];
+      [subscriber sendError:error];
+    } completed:^{
+      BOOL shouldComplete = NO;
+      [lock lock];
+      samplerCompleted = YES;
+      shouldComplete = selfCompleted;
+      [lock unlock];
 
-			if (shouldComplete) {
-				[sourceDisposable dispose];
-				[subscriber sendCompleted];
-			}
-		}];
+      if (shouldComplete) {
+        [sourceDisposable dispose];
+        [subscriber sendCompleted];
+      }
+    }];
 
-		return [RACDisposable disposableWithBlock:^{
-			[samplerDisposable dispose];
-			[sourceDisposable dispose];
-		}];
-	}] setNameWithFormat:@"[%@] -sample: %@", self.name, sampler];
+    return [RACDisposable disposableWithBlock:^{
+      [samplerDisposable dispose];
+      [sourceDisposable dispose];
+    }];
+  }] setNameWithFormat:@"[%@] -sample: %@", self.name, sampler];
 }
 
 - (RACSignal *)ignoreValues {
-	return [[self filter:^(id _) {
-		return NO;
-	}] setNameWithFormat:@"[%@] -ignoreValues", self.name];
+  return [[self filter:^(id _) {
+    return NO;
+  }] setNameWithFormat:@"[%@] -ignoreValues", self.name];
 }
 
 - (RACSignal *)materialize {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		return [self subscribeNext:^(id x) {
-			[subscriber sendNext:[RACEvent eventWithValue:x]];
-		} error:^(NSError *error) {
-			[subscriber sendNext:[RACEvent eventWithError:error]];
-			[subscriber sendCompleted];
-		} completed:^{
-			[subscriber sendNext:RACEvent.completedEvent];
-			[subscriber sendCompleted];
-		}];
-	}] setNameWithFormat:@"[%@] -materialize", self.name];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    return [self subscribeNext:^(id x) {
+      [subscriber sendNext:[RACEvent eventWithValue:x]];
+    } error:^(NSError *error) {
+      [subscriber sendNext:[RACEvent eventWithError:error]];
+      [subscriber sendCompleted];
+    } completed:^{
+      [subscriber sendNext:RACEvent.completedEvent];
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -materialize", self.name];
 }
 
 - (RACSignal *)dematerialize {
-	return [[self bind:^{
-		return ^(RACEvent *event, BOOL *stop) {
-			switch (event.eventType) {
-				case RACEventTypeCompleted:
-					*stop = YES;
-					return [RACSignal empty];
+  return [[self bind:^{
+    return ^(RACEvent *event, BOOL *stop) {
+      switch (event.eventType) {
+        case RACEventTypeCompleted:
+          *stop = YES;
+          return [RACSignal empty];
 
-				case RACEventTypeError:
-					*stop = YES;
-					return [RACSignal error:event.error];
+        case RACEventTypeError:
+          *stop = YES;
+          return [RACSignal error:event.error];
 
-				case RACEventTypeNext:
-					return [RACSignal return:event.value];
-			}
-		};
-	}] setNameWithFormat:@"[%@] -dematerialize", self.name];
+        case RACEventTypeNext:
+          return [RACSignal return:event.value];
+      }
+    };
+  }] setNameWithFormat:@"[%@] -dematerialize", self.name];
 }
 
 - (RACSignal *)not {
-	return [[self map:^(NSNumber *value) {
-		NSCAssert([value isKindOfClass:NSNumber.class], @"-not must only be used on a signal of NSNumbers. Instead, got: %@", value);
+  return [[self map:^(NSNumber *value) {
+    NSCAssert([value isKindOfClass:NSNumber.class], @"-not must only be used on a signal of NSNumbers. Instead, got: %@", value);
 
-		return @(!value.boolValue);
-	}] setNameWithFormat:@"[%@] -not", self.name];
+    return @(!value.boolValue);
+  }] setNameWithFormat:@"[%@] -not", self.name];
 }
 
 - (RACSignal *)and {
-	return [[self map:^(RACTuple *tuple) {
-		NSCAssert([tuple isKindOfClass:RACTuple.class], @"-and must only be used on a signal of RACTuples of NSNumbers. Instead, received: %@", tuple);
-		NSCAssert(tuple.count > 0, @"-and must only be used on a signal of RACTuples of NSNumbers, with at least 1 value in the tuple");
+  return [[self map:^(RACTuple *tuple) {
+    NSCAssert([tuple isKindOfClass:RACTuple.class], @"-and must only be used on a signal of RACTuples of NSNumbers. Instead, received: %@", tuple);
+    NSCAssert(tuple.count > 0, @"-and must only be used on a signal of RACTuples of NSNumbers, with at least 1 value in the tuple");
 
-		return @([tuple.rac_sequence all:^(NSNumber *number) {
-			NSCAssert([number isKindOfClass:NSNumber.class], @"-and must only be used on a signal of RACTuples of NSNumbers. Instead, tuple contains a non-NSNumber value: %@", tuple);
+    return @([tuple.rac_sequence all:^(NSNumber *number) {
+      NSCAssert([number isKindOfClass:NSNumber.class], @"-and must only be used on a signal of RACTuples of NSNumbers. Instead, tuple contains a non-NSNumber value: %@", tuple);
 
-			return number.boolValue;
-		}]);
-	}] setNameWithFormat:@"[%@] -and", self.name];
+      return number.boolValue;
+    }]);
+  }] setNameWithFormat:@"[%@] -and", self.name];
 }
 
 - (RACSignal *)or {
-	return [[self map:^(RACTuple *tuple) {
-		NSCAssert([tuple isKindOfClass:RACTuple.class], @"-or must only be used on a signal of RACTuples of NSNumbers. Instead, received: %@", tuple);
-		NSCAssert(tuple.count > 0, @"-or must only be used on a signal of RACTuples of NSNumbers, with at least 1 value in the tuple");
+  return [[self map:^(RACTuple *tuple) {
+    NSCAssert([tuple isKindOfClass:RACTuple.class], @"-or must only be used on a signal of RACTuples of NSNumbers. Instead, received: %@", tuple);
+    NSCAssert(tuple.count > 0, @"-or must only be used on a signal of RACTuples of NSNumbers, with at least 1 value in the tuple");
 
-		return @([tuple.rac_sequence any:^(NSNumber *number) {
-			NSCAssert([number isKindOfClass:NSNumber.class], @"-or must only be used on a signal of RACTuples of NSNumbers. Instead, tuple contains a non-NSNumber value: %@", tuple);
+    return @([tuple.rac_sequence any:^(NSNumber *number) {
+      NSCAssert([number isKindOfClass:NSNumber.class], @"-or must only be used on a signal of RACTuples of NSNumbers. Instead, tuple contains a non-NSNumber value: %@", tuple);
 
-			return number.boolValue;
-		}]);
-	}] setNameWithFormat:@"[%@] -or", self.name];
+      return number.boolValue;
+    }]);
+  }] setNameWithFormat:@"[%@] -or", self.name];
 }
 
 - (RACSignal *)reduceApply {
-	return [[self map:^(RACTuple *tuple) {
-		NSCAssert([tuple isKindOfClass:RACTuple.class], @"-reduceApply must only be used on a signal of RACTuples. Instead, received: %@", tuple);
-		NSCAssert(tuple.count > 1, @"-reduceApply must only be used on a signal of RACTuples, with at least a block in tuple[0] and its first argument in tuple[1]");
+  return [[self map:^(RACTuple *tuple) {
+    NSCAssert([tuple isKindOfClass:RACTuple.class], @"-reduceApply must only be used on a signal of RACTuples. Instead, received: %@", tuple);
+    NSCAssert(tuple.count > 1, @"-reduceApply must only be used on a signal of RACTuples, with at least a block in tuple[0] and its first argument in tuple[1]");
 
-		// We can't use -array, because we need to preserve RACTupleNil
-		NSMutableArray *tupleArray = [NSMutableArray arrayWithCapacity:tuple.count];
-		for (id val in tuple) {
-			[tupleArray addObject:val];
-		}
-		RACTuple *arguments = [RACTuple tupleWithObjectsFromArray:[tupleArray subarrayWithRange:NSMakeRange(1, tupleArray.count - 1)]];
+    // We can't use -array, because we need to preserve RACTupleNil
+    NSMutableArray *tupleArray = [NSMutableArray arrayWithCapacity:tuple.count];
+    for (id val in tuple) {
+      [tupleArray addObject:val];
+    }
+    RACTuple *arguments = [RACTuple tupleWithObjectsFromArray:[tupleArray subarrayWithRange:NSMakeRange(1, tupleArray.count - 1)]];
 
-		return RACInvokeBlock(tuple[0], arguments);
-	}] setNameWithFormat:@"[%@] -reduceApply", self.name];
+    return RACInvokeBlock(tuple[0], arguments);
+  }] setNameWithFormat:@"[%@] -reduceApply", self.name];
 }
 
 @end

--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -345,6 +345,22 @@
   }] setNameWithFormat:@"[%@] -map:", self.name];
 }
 
+- (instancetype)filter:(BOOL (^)(id))block {
+  NSCParameterAssert(block != nil);
+
+  return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+    return [self subscribeNext:^(id x) {
+      if (block(x)) {
+        [subscriber sendNext:x];
+      }
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -filter:", self.name];
+}
+
 @end
 
 @implementation RACSignal (Subscription)

--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -28,54 +28,54 @@
 #pragma mark Lifecycle
 
 + (RACSignal *)createSignal:(RACDisposable * (^)(id<RACSubscriber> subscriber))didSubscribe {
-	return [RACDynamicSignal createSignal:didSubscribe];
+  return [RACDynamicSignal createSignal:didSubscribe];
 }
 
 + (RACSignal *)error:(NSError *)error {
-	return [RACErrorSignal error:error];
+  return [RACErrorSignal error:error];
 }
 
 + (RACSignal *)never {
-	return [[self createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-		return nil;
-	}] setNameWithFormat:@"+never"];
+  return [[self createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+    return nil;
+  }] setNameWithFormat:@"+never"];
 }
 
 + (RACSignal *)startEagerlyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block {
-	NSCParameterAssert(scheduler != nil);
-	NSCParameterAssert(block != NULL);
+  NSCParameterAssert(scheduler != nil);
+  NSCParameterAssert(block != NULL);
 
-	RACSignal *signal = [self startLazilyWithScheduler:scheduler block:block];
-	// Subscribe to force the lazy signal to call its block.
-	[[signal publish] connect];
-	return [signal setNameWithFormat:@"+startEagerlyWithScheduler: %@ block:", scheduler];
+  RACSignal *signal = [self startLazilyWithScheduler:scheduler block:block];
+  // Subscribe to force the lazy signal to call its block.
+  [[signal publish] connect];
+  return [signal setNameWithFormat:@"+startEagerlyWithScheduler: %@ block:", scheduler];
 }
 
 + (RACSignal *)startLazilyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block {
-	NSCParameterAssert(scheduler != nil);
-	NSCParameterAssert(block != NULL);
+  NSCParameterAssert(scheduler != nil);
+  NSCParameterAssert(block != NULL);
 
-	RACMulticastConnection *connection = [[RACSignal
-		createSignal:^ id (id<RACSubscriber> subscriber) {
-			block(subscriber);
-			return nil;
-		}]
-		multicast:[RACReplaySubject subject]];
-	
-	return [[[RACSignal
-		createSignal:^ id (id<RACSubscriber> subscriber) {
-			[connection.signal subscribe:subscriber];
-			[connection connect];
-			return nil;
-		}]
-		subscribeOn:scheduler]
-		setNameWithFormat:@"+startLazilyWithScheduler: %@ block:", scheduler];
+  RACMulticastConnection *connection = [[RACSignal
+    createSignal:^ id (id<RACSubscriber> subscriber) {
+      block(subscriber);
+      return nil;
+    }]
+    multicast:[RACReplaySubject subject]];
+  
+  return [[[RACSignal
+    createSignal:^ id (id<RACSubscriber> subscriber) {
+      [connection.signal subscribe:subscriber];
+      [connection connect];
+      return nil;
+    }]
+    subscribeOn:scheduler]
+    setNameWithFormat:@"+startLazilyWithScheduler: %@ block:", scheduler];
 }
 
 #pragma mark NSObject
 
 - (NSString *)description {
-	return [NSString stringWithFormat:@"<%@: %p> name: %@", self.class, self, self.name];
+  return [NSString stringWithFormat:@"<%@: %p> name: %@", self.class, self, self.name];
 }
 
 @end
@@ -83,266 +83,266 @@
 @implementation RACSignal (RACStream)
 
 + (RACSignal *)empty {
-	return [RACEmptySignal empty];
+  return [RACEmptySignal empty];
 }
 
 + (RACSignal *)return:(id)value {
-	return [RACReturnSignal return:value];
+  return [RACReturnSignal return:value];
 }
 
 - (RACSignal *)bind:(RACSignalBindBlock (^)(void))block {
-	NSCParameterAssert(block != NULL);
+  NSCParameterAssert(block != NULL);
 
-	/*
-	 * -bind: should:
-	 * 
-	 * 1. Subscribe to the original signal of values.
-	 * 2. Any time the original signal sends a value, transform it using the binding block.
-	 * 3. If the binding block returns a signal, subscribe to it, and pass all of its values through to the subscriber as they're received.
-	 * 4. If the binding block asks the bind to terminate, complete the _original_ signal.
-	 * 5. When _all_ signals complete, send completed to the subscriber.
-	 * 
-	 * If any signal sends an error at any point, send that to the subscriber.
-	 */
+  /*
+   * -bind: should:
+   * 
+   * 1. Subscribe to the original signal of values.
+   * 2. Any time the original signal sends a value, transform it using the binding block.
+   * 3. If the binding block returns a signal, subscribe to it, and pass all of its values through to the subscriber as they're received.
+   * 4. If the binding block asks the bind to terminate, complete the _original_ signal.
+   * 5. When _all_ signals complete, send completed to the subscriber.
+   * 
+   * If any signal sends an error at any point, send that to the subscriber.
+   */
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACSignalBindBlock bindingBlock = block();
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACSignalBindBlock bindingBlock = block();
 
-		__block volatile int32_t signalCount = 1;   // indicates self
+    __block volatile int32_t signalCount = 1;   // indicates self
 
-		RACCompoundDisposable *compoundDisposable = [RACCompoundDisposable compoundDisposable];
+    RACCompoundDisposable *compoundDisposable = [RACCompoundDisposable compoundDisposable];
 
-		void (^completeSignal)(RACDisposable *) = ^(RACDisposable *finishedDisposable) {
-			if (OSAtomicDecrement32Barrier(&signalCount) == 0) {
-				[subscriber sendCompleted];
-				[compoundDisposable dispose];
-			} else {
-				[compoundDisposable removeDisposable:finishedDisposable];
-			}
-		};
+    void (^completeSignal)(RACDisposable *) = ^(RACDisposable *finishedDisposable) {
+      if (OSAtomicDecrement32Barrier(&signalCount) == 0) {
+        [subscriber sendCompleted];
+        [compoundDisposable dispose];
+      } else {
+        [compoundDisposable removeDisposable:finishedDisposable];
+      }
+    };
 
-		void (^addSignal)(RACSignal *) = ^(RACSignal *signal) {
-			OSAtomicIncrement32Barrier(&signalCount);
+    void (^addSignal)(RACSignal *) = ^(RACSignal *signal) {
+      OSAtomicIncrement32Barrier(&signalCount);
 
-			RACSerialDisposable *selfDisposable = [[RACSerialDisposable alloc] init];
-			[compoundDisposable addDisposable:selfDisposable];
+      RACSerialDisposable *selfDisposable = [[RACSerialDisposable alloc] init];
+      [compoundDisposable addDisposable:selfDisposable];
 
-			RACDisposable *disposable = [signal subscribeNext:^(id x) {
-				[subscriber sendNext:x];
-			} error:^(NSError *error) {
-				[compoundDisposable dispose];
-				[subscriber sendError:error];
-			} completed:^{
-				@autoreleasepool {
-					completeSignal(selfDisposable);
-				}
-			}];
+      RACDisposable *disposable = [signal subscribeNext:^(id x) {
+        [subscriber sendNext:x];
+      } error:^(NSError *error) {
+        [compoundDisposable dispose];
+        [subscriber sendError:error];
+      } completed:^{
+        @autoreleasepool {
+          completeSignal(selfDisposable);
+        }
+      }];
 
-			selfDisposable.disposable = disposable;
-		};
+      selfDisposable.disposable = disposable;
+    };
 
-		@autoreleasepool {
-			RACSerialDisposable *selfDisposable = [[RACSerialDisposable alloc] init];
-			[compoundDisposable addDisposable:selfDisposable];
+    @autoreleasepool {
+      RACSerialDisposable *selfDisposable = [[RACSerialDisposable alloc] init];
+      [compoundDisposable addDisposable:selfDisposable];
 
-			RACDisposable *bindingDisposable = [self subscribeNext:^(id x) {
-				// Manually check disposal to handle synchronous errors.
-				if (compoundDisposable.disposed) return;
+      RACDisposable *bindingDisposable = [self subscribeNext:^(id x) {
+        // Manually check disposal to handle synchronous errors.
+        if (compoundDisposable.disposed) return;
 
-				BOOL stop = NO;
-				id signal = bindingBlock(x, &stop);
+        BOOL stop = NO;
+        id signal = bindingBlock(x, &stop);
 
-				@autoreleasepool {
-					if (signal != nil) addSignal(signal);
-					if (signal == nil || stop) {
-						[selfDisposable dispose];
-						completeSignal(selfDisposable);
-					}
-				}
-			} error:^(NSError *error) {
-				[compoundDisposable dispose];
-				[subscriber sendError:error];
-			} completed:^{
-				@autoreleasepool {
-					completeSignal(selfDisposable);
-				}
-			}];
+        @autoreleasepool {
+          if (signal != nil) addSignal(signal);
+          if (signal == nil || stop) {
+            [selfDisposable dispose];
+            completeSignal(selfDisposable);
+          }
+        }
+      } error:^(NSError *error) {
+        [compoundDisposable dispose];
+        [subscriber sendError:error];
+      } completed:^{
+        @autoreleasepool {
+          completeSignal(selfDisposable);
+        }
+      }];
 
-			selfDisposable.disposable = bindingDisposable;
-		}
+      selfDisposable.disposable = bindingDisposable;
+    }
 
-		return compoundDisposable;
-	}] setNameWithFormat:@"[%@] -bind:", self.name];
+    return compoundDisposable;
+  }] setNameWithFormat:@"[%@] -bind:", self.name];
 }
 
 - (RACSignal *)concat:(RACSignal *)signal {
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACCompoundDisposable *compoundDisposable = [[RACCompoundDisposable alloc] init];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    RACCompoundDisposable *compoundDisposable = [[RACCompoundDisposable alloc] init];
 
-		RACDisposable *sourceDisposable = [self subscribeNext:^(id x) {
-			[subscriber sendNext:x];
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			RACDisposable *concattedDisposable = [signal subscribe:subscriber];
-			[compoundDisposable addDisposable:concattedDisposable];
-		}];
+    RACDisposable *sourceDisposable = [self subscribeNext:^(id x) {
+      [subscriber sendNext:x];
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      RACDisposable *concattedDisposable = [signal subscribe:subscriber];
+      [compoundDisposable addDisposable:concattedDisposable];
+    }];
 
-		[compoundDisposable addDisposable:sourceDisposable];
-		return compoundDisposable;
-	}] setNameWithFormat:@"[%@] -concat: %@", self.name, signal];
+    [compoundDisposable addDisposable:sourceDisposable];
+    return compoundDisposable;
+  }] setNameWithFormat:@"[%@] -concat: %@", self.name, signal];
 }
 
 + (instancetype)zip:(id<NSFastEnumeration>)signals {
-	return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-		RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
+  return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+    RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
 
-		NSMutableArray<RACSignal *> *signalsArray = [NSMutableArray array];
-		for (RACSignal *signal in signals) {
-			[signalsArray addObject:signal];
-		}
+    NSMutableArray<RACSignal *> *signalsArray = [NSMutableArray array];
+    for (RACSignal *signal in signals) {
+      [signalsArray addObject:signal];
+    }
 
-		NSUInteger signalsCount = signalsArray.count;
-		if (!signalsCount) {
-			[subscriber sendCompleted];
-			return nil;
-		}
+    NSUInteger signalsCount = signalsArray.count;
+    if (!signalsCount) {
+      [subscriber sendCompleted];
+      return nil;
+    }
 
-		// BOOL value indicates if the signal at index has completed.
-		__block NSMutableArray *completed = [NSMutableArray arrayWithCapacity:signalsCount];
-		// Array of arrays of values sent.
-		__block NSMutableArray *values = [NSMutableArray arrayWithCapacity:signalsCount];
-		for (NSUInteger i = 0; i < signalsCount; ++i) {
-			[completed addObject:@NO];
-			[values addObject:[NSMutableArray array]];
-		}
+    // BOOL value indicates if the signal at index has completed.
+    __block NSMutableArray *completed = [NSMutableArray arrayWithCapacity:signalsCount];
+    // Array of arrays of values sent.
+    __block NSMutableArray *values = [NSMutableArray arrayWithCapacity:signalsCount];
+    for (NSUInteger i = 0; i < signalsCount; ++i) {
+      [completed addObject:@NO];
+      [values addObject:[NSMutableArray array]];
+    }
 
-		void (^sendCompletedIfNecessary)(void) = ^{
-			for (NSUInteger i = 0; i < signalsCount; ++i) {
-				if (![values[i] count] && [completed[i] boolValue]) {
-					[subscriber sendCompleted];
-					return;
-				}
-			}
-		};
+    void (^sendCompletedIfNecessary)(void) = ^{
+      for (NSUInteger i = 0; i < signalsCount; ++i) {
+        if (![values[i] count] && [completed[i] boolValue]) {
+          [subscriber sendCompleted];
+          return;
+        }
+      }
+    };
 
-		for (NSUInteger i = 0; i < signalsArray.count; ++i) {
-			RACDisposable *innerDisposable = [signalsArray[i] subscribeNext:^(id x) {
-				@synchronized (values) {
-					[values[i] addObject:x ?: RACTupleNil.tupleNil];
+    for (NSUInteger i = 0; i < signalsArray.count; ++i) {
+      RACDisposable *innerDisposable = [signalsArray[i] subscribeNext:^(id x) {
+        @synchronized (values) {
+          [values[i] addObject:x ?: RACTupleNil.tupleNil];
 
-					for (NSArray *sentValues in values) {
-						if (!sentValues.count) {
-							return;
-						}
-					}
+          for (NSArray *sentValues in values) {
+            if (!sentValues.count) {
+              return;
+            }
+          }
 
-					NSMutableArray *valuesToSend = [NSMutableArray arrayWithCapacity:signalsCount];
-					for (NSMutableArray *sentValues in values) {
-						[valuesToSend addObject:sentValues.firstObject];
-						[sentValues removeObjectAtIndex:0];
-					}
+          NSMutableArray *valuesToSend = [NSMutableArray arrayWithCapacity:signalsCount];
+          for (NSMutableArray *sentValues in values) {
+            [valuesToSend addObject:sentValues.firstObject];
+            [sentValues removeObjectAtIndex:0];
+          }
 
-					RACTuple *tuple = [RACTuple tupleWithObjectsFromArray:valuesToSend];
+          RACTuple *tuple = [RACTuple tupleWithObjectsFromArray:valuesToSend];
 
-					[subscriber sendNext:tuple];
-					sendCompletedIfNecessary();
-				}
-			} error:^(NSError *error) {
-				[subscriber sendError:error];
-			} completed:^{
-				@synchronized (values) {
-					completed[i] = @YES;
-					sendCompletedIfNecessary();
-				}
-			}];
-			
-			[disposable addDisposable:innerDisposable];
-		}
+          [subscriber sendNext:tuple];
+          sendCompletedIfNecessary();
+        }
+      } error:^(NSError *error) {
+        [subscriber sendError:error];
+      } completed:^{
+        @synchronized (values) {
+          completed[i] = @YES;
+          sendCompletedIfNecessary();
+        }
+      }];
+      
+      [disposable addDisposable:innerDisposable];
+    }
 
-		return disposable;
-	}] setNameWithFormat:@"+zip: %@", signals];
+    return disposable;
+  }] setNameWithFormat:@"+zip: %@", signals];
 }
 
 - (RACSignal *)zipWith:(RACSignal *)signal {
-	NSCParameterAssert(signal != nil);
+  NSCParameterAssert(signal != nil);
 
-	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		__block BOOL selfCompleted = NO;
-		NSMutableArray *selfValues = [NSMutableArray array];
+  return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    __block BOOL selfCompleted = NO;
+    NSMutableArray *selfValues = [NSMutableArray array];
 
-		__block BOOL otherCompleted = NO;
-		NSMutableArray *otherValues = [NSMutableArray array];
+    __block BOOL otherCompleted = NO;
+    NSMutableArray *otherValues = [NSMutableArray array];
 
-		void (^sendCompletedIfNecessary)(void) = ^{
-			@synchronized (selfValues) {
-				BOOL selfEmpty = (selfCompleted && selfValues.count == 0);
-				BOOL otherEmpty = (otherCompleted && otherValues.count == 0);
-				if (selfEmpty || otherEmpty) [subscriber sendCompleted];
-			}
-		};
+    void (^sendCompletedIfNecessary)(void) = ^{
+      @synchronized (selfValues) {
+        BOOL selfEmpty = (selfCompleted && selfValues.count == 0);
+        BOOL otherEmpty = (otherCompleted && otherValues.count == 0);
+        if (selfEmpty || otherEmpty) [subscriber sendCompleted];
+      }
+    };
 
-		void (^sendNext)(void) = ^{
-			@synchronized (selfValues) {
-				if (selfValues.count == 0) return;
-				if (otherValues.count == 0) return;
+    void (^sendNext)(void) = ^{
+      @synchronized (selfValues) {
+        if (selfValues.count == 0) return;
+        if (otherValues.count == 0) return;
 
-				RACTuple *tuple = RACTuplePack(selfValues[0], otherValues[0]);
-				[selfValues removeObjectAtIndex:0];
-				[otherValues removeObjectAtIndex:0];
+        RACTuple *tuple = RACTuplePack(selfValues[0], otherValues[0]);
+        [selfValues removeObjectAtIndex:0];
+        [otherValues removeObjectAtIndex:0];
 
-				[subscriber sendNext:tuple];
-				sendCompletedIfNecessary();
-			}
-		};
+        [subscriber sendNext:tuple];
+        sendCompletedIfNecessary();
+      }
+    };
 
-		RACDisposable *selfDisposable = [self subscribeNext:^(id x) {
-			@synchronized (selfValues) {
-				[selfValues addObject:x ?: RACTupleNil.tupleNil];
-				sendNext();
-			}
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			@synchronized (selfValues) {
-				selfCompleted = YES;
-				sendCompletedIfNecessary();
-			}
-		}];
+    RACDisposable *selfDisposable = [self subscribeNext:^(id x) {
+      @synchronized (selfValues) {
+        [selfValues addObject:x ?: RACTupleNil.tupleNil];
+        sendNext();
+      }
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      @synchronized (selfValues) {
+        selfCompleted = YES;
+        sendCompletedIfNecessary();
+      }
+    }];
 
-		RACDisposable *otherDisposable = [signal subscribeNext:^(id x) {
-			@synchronized (selfValues) {
-				[otherValues addObject:x ?: RACTupleNil.tupleNil];
-				sendNext();
-			}
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			@synchronized (selfValues) {
-				otherCompleted = YES;
-				sendCompletedIfNecessary();
-			}
-		}];
+    RACDisposable *otherDisposable = [signal subscribeNext:^(id x) {
+      @synchronized (selfValues) {
+        [otherValues addObject:x ?: RACTupleNil.tupleNil];
+        sendNext();
+      }
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      @synchronized (selfValues) {
+        otherCompleted = YES;
+        sendCompletedIfNecessary();
+      }
+    }];
 
-		return [RACDisposable disposableWithBlock:^{
-			[selfDisposable dispose];
-			[otherDisposable dispose];
-		}];
-	}] setNameWithFormat:@"[%@] -zipWith: %@", self.name, signal];
+    return [RACDisposable disposableWithBlock:^{
+      [selfDisposable dispose];
+      [otherDisposable dispose];
+    }];
+  }] setNameWithFormat:@"[%@] -zipWith: %@", self.name, signal];
 }
 
 - (instancetype)map:(id (^)(id value))block {
-	NSCParameterAssert(block != nil);
+  NSCParameterAssert(block != nil);
 
-	return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-		return [self subscribeNext:^(id x) {
-			[subscriber sendNext:block(x)];
-		} error:^(NSError *error) {
-			[subscriber sendError:error];
-		} completed:^{
-			[subscriber sendCompleted];
-		}];
-	}] setNameWithFormat:@"[%@] -map:", self.name];
+  return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+    return [self subscribeNext:^(id x) {
+      [subscriber sendNext:block(x)];
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -map:", self.name];
 }
 
 @end
@@ -350,62 +350,62 @@
 @implementation RACSignal (Subscription)
 
 - (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
-	NSCAssert(NO, @"This method must be overridden by subclasses");
-	return nil;
+  NSCAssert(NO, @"This method must be overridden by subclasses");
+  return nil;
 }
 
 - (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock {
-	NSCParameterAssert(nextBlock != NULL);
-	
-	RACSubscriber *o = [RACSubscriber subscriberWithNext:nextBlock error:NULL completed:NULL];
-	return [self subscribe:o];
+  NSCParameterAssert(nextBlock != NULL);
+  
+  RACSubscriber *o = [RACSubscriber subscriberWithNext:nextBlock error:NULL completed:NULL];
+  return [self subscribe:o];
 }
 
 - (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock completed:(void (^)(void))completedBlock {
-	NSCParameterAssert(nextBlock != NULL);
-	NSCParameterAssert(completedBlock != NULL);
-	
-	RACSubscriber *o = [RACSubscriber subscriberWithNext:nextBlock error:NULL completed:completedBlock];
-	return [self subscribe:o];
+  NSCParameterAssert(nextBlock != NULL);
+  NSCParameterAssert(completedBlock != NULL);
+  
+  RACSubscriber *o = [RACSubscriber subscriberWithNext:nextBlock error:NULL completed:completedBlock];
+  return [self subscribe:o];
 }
 
 - (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock completed:(void (^)(void))completedBlock {
-	NSCParameterAssert(nextBlock != NULL);
-	NSCParameterAssert(errorBlock != NULL);
-	NSCParameterAssert(completedBlock != NULL);
-	
-	RACSubscriber *o = [RACSubscriber subscriberWithNext:nextBlock error:errorBlock completed:completedBlock];
-	return [self subscribe:o];
+  NSCParameterAssert(nextBlock != NULL);
+  NSCParameterAssert(errorBlock != NULL);
+  NSCParameterAssert(completedBlock != NULL);
+  
+  RACSubscriber *o = [RACSubscriber subscriberWithNext:nextBlock error:errorBlock completed:completedBlock];
+  return [self subscribe:o];
 }
 
 - (RACDisposable *)subscribeError:(void (^)(NSError *error))errorBlock {
-	NSCParameterAssert(errorBlock != NULL);
-	
-	RACSubscriber *o = [RACSubscriber subscriberWithNext:NULL error:errorBlock completed:NULL];
-	return [self subscribe:o];
+  NSCParameterAssert(errorBlock != NULL);
+  
+  RACSubscriber *o = [RACSubscriber subscriberWithNext:NULL error:errorBlock completed:NULL];
+  return [self subscribe:o];
 }
 
 - (RACDisposable *)subscribeCompleted:(void (^)(void))completedBlock {
-	NSCParameterAssert(completedBlock != NULL);
-	
-	RACSubscriber *o = [RACSubscriber subscriberWithNext:NULL error:NULL completed:completedBlock];
-	return [self subscribe:o];
+  NSCParameterAssert(completedBlock != NULL);
+  
+  RACSubscriber *o = [RACSubscriber subscriberWithNext:NULL error:NULL completed:completedBlock];
+  return [self subscribe:o];
 }
 
 - (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock {
-	NSCParameterAssert(nextBlock != NULL);
-	NSCParameterAssert(errorBlock != NULL);
-	
-	RACSubscriber *o = [RACSubscriber subscriberWithNext:nextBlock error:errorBlock completed:NULL];
-	return [self subscribe:o];
+  NSCParameterAssert(nextBlock != NULL);
+  NSCParameterAssert(errorBlock != NULL);
+  
+  RACSubscriber *o = [RACSubscriber subscriberWithNext:nextBlock error:errorBlock completed:NULL];
+  return [self subscribe:o];
 }
 
 - (RACDisposable *)subscribeError:(void (^)(NSError *))errorBlock completed:(void (^)(void))completedBlock {
-	NSCParameterAssert(completedBlock != NULL);
-	NSCParameterAssert(errorBlock != NULL);
-	
-	RACSubscriber *o = [RACSubscriber subscriberWithNext:NULL error:errorBlock completed:completedBlock];
-	return [self subscribe:o];
+  NSCParameterAssert(completedBlock != NULL);
+  NSCParameterAssert(errorBlock != NULL);
+  
+  RACSubscriber *o = [RACSubscriber subscriberWithNext:NULL error:errorBlock completed:completedBlock];
+  return [self subscribe:o];
 }
 
 @end
@@ -413,25 +413,25 @@
 @implementation RACSignal (Debugging)
 
 - (RACSignal *)logAll {
-	return [[[self logNext] logError] logCompleted];
+  return [[[self logNext] logError] logCompleted];
 }
 
 - (RACSignal *)logNext {
-	return [[self doNext:^(id x) {
-		NSLog(@"%@ next: %@", self, x);
-	}] setNameWithFormat:@"%@", self.name];
+  return [[self doNext:^(id x) {
+    NSLog(@"%@ next: %@", self, x);
+  }] setNameWithFormat:@"%@", self.name];
 }
 
 - (RACSignal *)logError {
-	return [[self doError:^(NSError *error) {
-		NSLog(@"%@ error: %@", self, error);
-	}] setNameWithFormat:@"%@", self.name];
+  return [[self doError:^(NSError *error) {
+    NSLog(@"%@ error: %@", self, error);
+  }] setNameWithFormat:@"%@", self.name];
 }
 
 - (RACSignal *)logCompleted {
-	return [[self doCompleted:^{
-		NSLog(@"%@ completed", self);
-	}] setNameWithFormat:@"%@", self.name];
+  return [[self doCompleted:^{
+    NSLog(@"%@ completed", self);
+  }] setNameWithFormat:@"%@", self.name];
 }
 
 @end
@@ -441,54 +441,54 @@
 static const NSTimeInterval RACSignalAsynchronousWaitTimeout = 10;
 
 - (id)asynchronousFirstOrDefault:(id)defaultValue success:(BOOL *)success error:(NSError **)error {
-	return [self asynchronousFirstOrDefault:defaultValue success:success error:error timeout:RACSignalAsynchronousWaitTimeout];
+  return [self asynchronousFirstOrDefault:defaultValue success:success error:error timeout:RACSignalAsynchronousWaitTimeout];
 }
 
 - (id)asynchronousFirstOrDefault:(id)defaultValue success:(BOOL *)success error:(NSError **)error timeout:(NSTimeInterval)timeout {
-	NSCAssert([NSThread isMainThread], @"%s should only be used from the main thread", __func__);
+  NSCAssert([NSThread isMainThread], @"%s should only be used from the main thread", __func__);
 
-	__block id result = defaultValue;
-	__block BOOL done = NO;
+  __block id result = defaultValue;
+  __block BOOL done = NO;
 
-	// Ensures that we don't pass values across thread boundaries by reference.
-	__block NSError *localError;
-	__block BOOL localSuccess = YES;
+  // Ensures that we don't pass values across thread boundaries by reference.
+  __block NSError *localError;
+  __block BOOL localSuccess = YES;
 
-	[[[[self
-		take:1]
-		timeout:timeout onScheduler:[RACScheduler scheduler]]
-		deliverOn:RACScheduler.mainThreadScheduler]
-		subscribeNext:^(id x) {
-			result = x;
-			done = YES;
-		} error:^(NSError *e) {
-			if (!done) {
-				localSuccess = NO;
-				localError = e;
-				done = YES;
-			}
-		} completed:^{
-			done = YES;
-		}];
-	
-	do {
-		[NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-	} while (!done);
+  [[[[self
+    take:1]
+    timeout:timeout onScheduler:[RACScheduler scheduler]]
+    deliverOn:RACScheduler.mainThreadScheduler]
+    subscribeNext:^(id x) {
+      result = x;
+      done = YES;
+    } error:^(NSError *e) {
+      if (!done) {
+        localSuccess = NO;
+        localError = e;
+        done = YES;
+      }
+    } completed:^{
+      done = YES;
+    }];
+  
+  do {
+    [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+  } while (!done);
 
-	if (success != NULL) *success = localSuccess;
-	if (error != NULL) *error = localError;
+  if (success != NULL) *success = localSuccess;
+  if (error != NULL) *error = localError;
 
-	return result;
+  return result;
 }
 
 - (BOOL)asynchronouslyWaitUntilCompleted:(NSError **)error timeout:(NSTimeInterval)timeout {
-	BOOL success = NO;
-	[[self ignoreValues] asynchronousFirstOrDefault:nil success:&success error:error timeout:timeout];
-	return success;
+  BOOL success = NO;
+  [[self ignoreValues] asynchronousFirstOrDefault:nil success:&success error:error timeout:timeout];
+  return success;
 }
 
 - (BOOL)asynchronouslyWaitUntilCompleted:(NSError **)error {
-	return [self asynchronouslyWaitUntilCompleted:error timeout:RACSignalAsynchronousWaitTimeout];
+  return [self asynchronouslyWaitUntilCompleted:error timeout:RACSignalAsynchronousWaitTimeout];
 }
 
 @end

--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -494,6 +494,24 @@
           RACDescription(startingValue)];
 }
 
+- (instancetype)takeUntilBlock:(BOOL (^)(id x))predicate {
+  NSCParameterAssert(predicate != nil);
+
+  return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+    return [self subscribeNext:^(id x) {
+      if (predicate(x)) {
+        [subscriber sendCompleted];
+      } else {
+        [subscriber sendNext:x];
+      }
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -takeUntilBlock:", self.name];
+}
+
 @end
 
 @implementation RACSignal (Subscription)

--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -405,6 +405,30 @@
   }];
 }
 
+- (instancetype)skip:(NSUInteger)skipCount {
+  if (!skipCount) {
+    return self;
+  }
+
+  return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+    __block NSUInteger skipped = 0;
+
+    return [self subscribeNext:^(id x) {
+      if (skipped >= skipCount) {
+        [subscriber sendNext:x];
+        return;
+      }
+      ++skipped;
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -skip: %lu", self.name, (unsigned long)skipCount];
+}
+
+}
+
 @end
 
 @implementation RACSignal (Subscription)

--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -13,6 +13,7 @@
 #import "RACEmptySignal.h"
 #import "RACErrorSignal.h"
 #import "RACMulticastConnection.h"
+#import "NSObject+RACDescription.h"
 #import "RACReplaySubject.h"
 #import "RACReturnSignal.h"
 #import "RACScheduler.h"
@@ -475,6 +476,22 @@
       [subscriber sendCompleted];
     }];
   }] setNameWithFormat:@"[%@] -distinctUntilChanged", self.name];
+}
+
+- (instancetype)scanWithStart:(id)startingValue reduceWithIndex:(id (^)(id, id, NSUInteger))reduceBlock {
+  NSCParameterAssert(reduceBlock != nil);
+
+  return [[RACSignal defer:^RACSignal *{
+    __block id running = startingValue;
+    __block NSUInteger idx = 0;
+
+    return [self map:^id(id value) {
+      running = reduceBlock(running, value, idx);
+      ++idx;
+      return running;
+    }];
+  }] setNameWithFormat:@"[%@] -scanWithStart: %@ reduceWithIndex:", self.name,
+          RACDescription(startingValue)];
 }
 
 @end

--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -512,6 +512,28 @@
   }] setNameWithFormat:@"[%@] -takeUntilBlock:", self.name];
 }
 
+- (instancetype)skipUntilBlock:(BOOL (^)(id x))predicate {
+  NSCParameterAssert(predicate != nil);
+
+  return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+    __block BOOL skipping = YES;
+
+    return [self subscribeNext:^(id x) {
+      if (skipping) {
+        skipping &= !predicate(x);
+      }
+
+      if (!skipping) {
+        [subscriber sendNext:x];
+      }
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -skipUntilBlock:", self.name];
+}
+
 @end
 
 @implementation RACSignal (Subscription)

--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -455,6 +455,28 @@
   }] setNameWithFormat:@"[%@] -take: %lu", self.name, (unsigned long)count];
 }
 
+- (instancetype)distinctUntilChanged {
+  return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+    __block id lastValue = nil;
+    __block BOOL initial = YES;
+
+    return [self subscribeNext:^(id x) {
+      BOOL isEqual = lastValue == x || [x isEqual:lastValue];
+      if (!initial && isEqual) {
+        return;
+      }
+
+      initial = NO;
+      lastValue = x;
+      [subscriber sendNext:x];
+    } error:^(NSError *error) {
+      [subscriber sendError:error];
+    } completed:^{
+      [subscriber sendCompleted];
+    }];
+  }] setNameWithFormat:@"[%@] -distinctUntilChanged", self.name];
+}
+
 @end
 
 @implementation RACSignal (Subscription)

--- a/ReactiveObjCTests/RACSignalSpec.m
+++ b/ReactiveObjCTests/RACSignalSpec.m
@@ -44,39 +44,39 @@ static NSString * const RACSignalMaxConcurrent = @"RACSignalMaxConcurrent";
 QuickConfigurationBegin(mergeConcurrentCompletionName)
 
 + (void)configure:(Configuration *)configuration {
-	sharedExamples(RACSignalMergeConcurrentCompletionExampleGroup, ^(QCKDSLSharedExampleContext exampleContext) {
-		qck_it(@"should complete only after the source and all its signals have completed", ^{
-			RACSubject *subject1 = [RACSubject subject];
-			RACSubject *subject2 = [RACSubject subject];
-			RACSubject *subject3 = [RACSubject subject];
+  sharedExamples(RACSignalMergeConcurrentCompletionExampleGroup, ^(QCKDSLSharedExampleContext exampleContext) {
+    qck_it(@"should complete only after the source and all its signals have completed", ^{
+      RACSubject *subject1 = [RACSubject subject];
+      RACSubject *subject2 = [RACSubject subject];
+      RACSubject *subject3 = [RACSubject subject];
 
-			RACSubject *signalsSubject = [RACSubject subject];
-			__block BOOL completed = NO;
-			[[signalsSubject flatten:[exampleContext()[RACSignalMaxConcurrent] unsignedIntegerValue]] subscribeCompleted:^{
-				completed = YES;
-			}];
+      RACSubject *signalsSubject = [RACSubject subject];
+      __block BOOL completed = NO;
+      [[signalsSubject flatten:[exampleContext()[RACSignalMaxConcurrent] unsignedIntegerValue]] subscribeCompleted:^{
+        completed = YES;
+      }];
 
-			[signalsSubject sendNext:subject1];
-			[subject1 sendCompleted];
+      [signalsSubject sendNext:subject1];
+      [subject1 sendCompleted];
 
-			expect(@(completed)).to(beFalsy());
+      expect(@(completed)).to(beFalsy());
 
-			[signalsSubject sendNext:subject2];
-			[signalsSubject sendNext:subject3];
+      [signalsSubject sendNext:subject2];
+      [signalsSubject sendNext:subject3];
 
-			[signalsSubject sendCompleted];
+      [signalsSubject sendCompleted];
 
-			expect(@(completed)).to(beFalsy());
+      expect(@(completed)).to(beFalsy());
 
-			[subject2 sendCompleted];
+      [subject2 sendCompleted];
 
-			expect(@(completed)).to(beFalsy());
+      expect(@(completed)).to(beFalsy());
 
-			[subject3 sendCompleted];
+      [subject3 sendCompleted];
 
-			expect(@(completed)).to(beTruthy());
-		});
-	});
+      expect(@(completed)).to(beTruthy());
+    });
+  });
 }
 
 QuickConfigurationEnd
@@ -84,4030 +84,4030 @@ QuickConfigurationEnd
 QuickSpecBegin(RACSignalSpec)
 
 qck_beforeSuite(^{
-	// We do this instead of a macro to ensure that to(equal() will work
-	// correctly (by matching identity), even if -[NSError isEqual:] is broken.
-	RACSignalTestError = [NSError errorWithDomain:@"foo" code:100 userInfo:nil];
+  // We do this instead of a macro to ensure that to(equal() will work
+  // correctly (by matching identity), even if -[NSError isEqual:] is broken.
+  RACSignalTestError = [NSError errorWithDomain:@"foo" code:100 userInfo:nil];
 });
 
 qck_describe(@"RACStream", ^{
-	id verifyValues = ^(RACSignal *signal, NSArray *expectedValues) {
-		expect(signal).notTo(beNil());
+  id verifyValues = ^(RACSignal *signal, NSArray *expectedValues) {
+    expect(signal).notTo(beNil());
 
-		NSMutableArray *collectedValues = [NSMutableArray array];
+    NSMutableArray *collectedValues = [NSMutableArray array];
 
-		__block BOOL success = NO;
-		__block NSError *error = nil;
-		[signal subscribeNext:^(id value) {
-			[collectedValues addObject:value];
-		} error:^(NSError *receivedError) {
-			error = receivedError;
-		} completed:^{
-			success = YES;
-		}];
+    __block BOOL success = NO;
+    __block NSError *error = nil;
+    [signal subscribeNext:^(id value) {
+      [collectedValues addObject:value];
+    } error:^(NSError *receivedError) {
+      error = receivedError;
+    } completed:^{
+      success = YES;
+    }];
 
-		expect(@(success)).toEventually(beTruthy());
-		expect(error).to(beNil());
-		expect(collectedValues).to(equal(expectedValues));
-	};
+    expect(@(success)).toEventually(beTruthy());
+    expect(error).to(beNil());
+    expect(collectedValues).to(equal(expectedValues));
+  };
 
-	RACSignal *infiniteSignal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		__block volatile int32_t done = 0;
+  RACSignal *infiniteSignal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+    __block volatile int32_t done = 0;
 
-		[RACScheduler.mainThreadScheduler schedule:^{
-			while (!done) {
-				[subscriber sendNext:RACUnit.defaultUnit];
-			}
-		}];
+    [RACScheduler.mainThreadScheduler schedule:^{
+      while (!done) {
+        [subscriber sendNext:RACUnit.defaultUnit];
+      }
+    }];
 
-		return [RACDisposable disposableWithBlock:^{
-			OSAtomicIncrement32Barrier(&done);
-		}];
-	}];
+    return [RACDisposable disposableWithBlock:^{
+      OSAtomicIncrement32Barrier(&done);
+    }];
+  }];
 
-	qck_itBehavesLike(RACStreamExamples, ^{
-		return @{
-			RACStreamExamplesClass: RACSignal.class,
-			RACStreamExamplesVerifyValuesBlock: verifyValues,
-			RACStreamExamplesInfiniteStream: infiniteSignal
-		};
-	});
+  qck_itBehavesLike(RACStreamExamples, ^{
+    return @{
+      RACStreamExamplesClass: RACSignal.class,
+      RACStreamExamplesVerifyValuesBlock: verifyValues,
+      RACStreamExamplesInfiniteStream: infiniteSignal
+    };
+  });
 });
 
 qck_describe(@"-bind:", ^{
-	__block RACSubject *signals;
-	__block BOOL disposed;
-	__block id lastValue;
-	__block RACSubject *values;
+  __block RACSubject *signals;
+  __block BOOL disposed;
+  __block id lastValue;
+  __block RACSubject *values;
 
-	qck_beforeEach(^{
-		// Tests send a (RACSignal, BOOL) pair that are used below in -bind:.
-		signals = [RACSubject subject];
+  qck_beforeEach(^{
+    // Tests send a (RACSignal, BOOL) pair that are used below in -bind:.
+    signals = [RACSubject subject];
 
-		disposed = NO;
-		RACSignal *source = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			[signals subscribe:subscriber];
+    disposed = NO;
+    RACSignal *source = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      [signals subscribe:subscriber];
 
-			return [RACDisposable disposableWithBlock:^{
-				disposed = YES;
-			}];
-		}];
+      return [RACDisposable disposableWithBlock:^{
+        disposed = YES;
+      }];
+    }];
 
-		RACSignal *bind = [source bind:^{
-			return ^(RACTuple *x, BOOL *stop) {
-				RACTupleUnpack(RACSignal *signal, NSNumber *stopValue) = x;
-				*stop = stopValue.boolValue;
-				return signal;
-			};
-		}];
+    RACSignal *bind = [source bind:^{
+      return ^(RACTuple *x, BOOL *stop) {
+        RACTupleUnpack(RACSignal *signal, NSNumber *stopValue) = x;
+        *stop = stopValue.boolValue;
+        return signal;
+      };
+    }];
 
-		lastValue = nil;
-		[bind subscribeNext:^(id x) {
-			lastValue = x;
-		}];
+    lastValue = nil;
+    [bind subscribeNext:^(id x) {
+      lastValue = x;
+    }];
 
-		// Send `bind` an open ended subject to subscribe to( These tests make
-		// use of this in two ways:
-		//   1. Used to test a regression bug where -bind: would not actually
-		//      stop when instructed to. This bug manifested itself only when
-		//      there were subscriptions that lived on past the point at which
-		//      -bind: was stopped. This subject represents such a subscription.
-		//   2. Test that values sent by this subject are received by `bind`'s
-		//      subscriber, even *after* -bind: has been instructed to stop.
-		values = [RACSubject subject];
-		[signals sendNext:RACTuplePack(values, @NO)];
-		expect(@(disposed)).to(beFalsy());
-	});
+    // Send `bind` an open ended subject to subscribe to( These tests make
+    // use of this in two ways:
+    //   1. Used to test a regression bug where -bind: would not actually
+    //      stop when instructed to. This bug manifested itself only when
+    //      there were subscriptions that lived on past the point at which
+    //      -bind: was stopped. This subject represents such a subscription.
+    //   2. Test that values sent by this subject are received by `bind`'s
+    //      subscriber, even *after* -bind: has been instructed to stop.
+    values = [RACSubject subject];
+    [signals sendNext:RACTuplePack(values, @NO)];
+    expect(@(disposed)).to(beFalsy());
+  });
 
-	qck_it(@"should dispose source signal when stopped with nil signal", ^{
-		// Tell -bind: to stop by sending it a `nil` signal.
-		[signals sendNext:RACTuplePack(nil, @NO)];
-		expect(@(disposed)).to(beTruthy());
+  qck_it(@"should dispose source signal when stopped with nil signal", ^{
+    // Tell -bind: to stop by sending it a `nil` signal.
+    [signals sendNext:RACTuplePack(nil, @NO)];
+    expect(@(disposed)).to(beTruthy());
 
-		// Should still receive values sent after stopping.
-		expect(lastValue).to(beNil());
-		[values sendNext:RACUnit.defaultUnit];
-		expect(lastValue).to(equal(RACUnit.defaultUnit));
-	});
+    // Should still receive values sent after stopping.
+    expect(lastValue).to(beNil());
+    [values sendNext:RACUnit.defaultUnit];
+    expect(lastValue).to(equal(RACUnit.defaultUnit));
+  });
 
-	qck_it(@"should dispose source signal when stop flag set to YES", ^{
-		// Tell -bind: to stop by setting the stop flag to YES.
-		[signals sendNext:RACTuplePack([RACSignal return:@1], @YES)];
-		expect(@(disposed)).to(beTruthy());
+  qck_it(@"should dispose source signal when stop flag set to YES", ^{
+    // Tell -bind: to stop by setting the stop flag to YES.
+    [signals sendNext:RACTuplePack([RACSignal return:@1], @YES)];
+    expect(@(disposed)).to(beTruthy());
 
-		// Should still recieve last signal sent at the time of setting stop to YES.
-		expect(lastValue).to(equal(@1));
+    // Should still recieve last signal sent at the time of setting stop to YES.
+    expect(lastValue).to(equal(@1));
 
-		// Should still receive values sent after stopping.
-		[values sendNext:@2];
-		expect(lastValue).to(equal(@2));
-	});
+    // Should still receive values sent after stopping.
+    [values sendNext:@2];
+    expect(lastValue).to(equal(@2));
+  });
 
-	qck_it(@"should properly stop subscribing to new signals after error", ^{
-		RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@0];
-			[subscriber sendNext:@1];
-			return nil;
-		}];
+  qck_it(@"should properly stop subscribing to new signals after error", ^{
+    RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@0];
+      [subscriber sendNext:@1];
+      return nil;
+    }];
 
-		__block BOOL subscribedAfterError = NO;
-		RACSignal *bind = [signal bind:^{
-			return ^(NSNumber *x, BOOL *stop) {
-				if (x.integerValue == 0) return [RACSignal error:nil];
+    __block BOOL subscribedAfterError = NO;
+    RACSignal *bind = [signal bind:^{
+      return ^(NSNumber *x, BOOL *stop) {
+        if (x.integerValue == 0) return [RACSignal error:nil];
 
-				return [RACSignal defer:^{
-					subscribedAfterError = YES;
-					return [RACSignal empty];
-				}];
-			};
-		}];
+        return [RACSignal defer:^{
+          subscribedAfterError = YES;
+          return [RACSignal empty];
+        }];
+      };
+    }];
 
-		[bind subscribeCompleted:^{}];
-		expect(@(subscribedAfterError)).to(beFalsy());
-	});
+    [bind subscribeCompleted:^{}];
+    expect(@(subscribedAfterError)).to(beFalsy());
+  });
 
-	qck_it(@"should not subscribe to signals following error in +merge:", ^{
-		__block BOOL firstSubscribed = NO;
-		__block BOOL secondSubscribed = NO;
-		__block BOOL errored = NO;
+  qck_it(@"should not subscribe to signals following error in +merge:", ^{
+    __block BOOL firstSubscribed = NO;
+    __block BOOL secondSubscribed = NO;
+    __block BOOL errored = NO;
 
-		RACSignal *signal = [[RACSignal
-			merge:@[
-				[RACSignal defer:^{
-					firstSubscribed = YES;
-					return [RACSignal error:nil];
-				}],
-				[RACSignal defer:^{
-					secondSubscribed = YES;
-					return [RACSignal return:nil];
-				}]
-			]]
-			doError:^(NSError *error) {
-				errored = YES;
-			}];
+    RACSignal *signal = [[RACSignal
+      merge:@[
+        [RACSignal defer:^{
+          firstSubscribed = YES;
+          return [RACSignal error:nil];
+        }],
+        [RACSignal defer:^{
+          secondSubscribed = YES;
+          return [RACSignal return:nil];
+        }]
+      ]]
+      doError:^(NSError *error) {
+        errored = YES;
+      }];
 
-		[signal subscribeCompleted:^{}];
+    [signal subscribeCompleted:^{}];
 
-		expect(@(firstSubscribed)).to(beTruthy());
-		expect(@(secondSubscribed)).to(beFalsy());
-		expect(@(errored)).to(beTruthy());
-	});
-	
-	qck_it(@"should not retain signals that are subscribed", ^{
-		__weak RACSignal *weakSignal;
-		@autoreleasepool {
-			RACSignal *delaySignal = [[RACSignal return:@123] delay:1];
-			[[delaySignal map:^id(id value) {
-				return @456;
-			}] subscribeNext:^(id x) {
-			}];
-			weakSignal = delaySignal;
-		}
-		expect(weakSignal).to(beNil());
-	});
+    expect(@(firstSubscribed)).to(beTruthy());
+    expect(@(secondSubscribed)).to(beFalsy());
+    expect(@(errored)).to(beTruthy());
+  });
+  
+  qck_it(@"should not retain signals that are subscribed", ^{
+    __weak RACSignal *weakSignal;
+    @autoreleasepool {
+      RACSignal *delaySignal = [[RACSignal return:@123] delay:1];
+      [[delaySignal map:^id(id value) {
+        return @456;
+      }] subscribeNext:^(id x) {
+      }];
+      weakSignal = delaySignal;
+    }
+    expect(weakSignal).to(beNil());
+  });
 });
 
 qck_describe(@"subscribing", ^{
-	__block RACSignal *signal = nil;
-	id nextValueSent = @"1";
+  __block RACSignal *signal = nil;
+  id nextValueSent = @"1";
 
-	qck_beforeEach(^{
-		signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:nextValueSent];
-			[subscriber sendCompleted];
-			return nil;
-		}];
-	});
+  qck_beforeEach(^{
+    signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:nextValueSent];
+      [subscriber sendCompleted];
+      return nil;
+    }];
+  });
 
-	qck_it(@"should get next values", ^{
-		__block id nextValueReceived = nil;
-		[signal subscribeNext:^(id x) {
-			nextValueReceived = x;
-		} error:^(NSError *error) {
+  qck_it(@"should get next values", ^{
+    __block id nextValueReceived = nil;
+    [signal subscribeNext:^(id x) {
+      nextValueReceived = x;
+    } error:^(NSError *error) {
 
-		} completed:^{
+    } completed:^{
 
-		}];
+    }];
 
-		expect(nextValueReceived).to(equal(nextValueSent));
-	});
+    expect(nextValueReceived).to(equal(nextValueSent));
+  });
 
-	qck_it(@"should get completed", ^{
-		__block BOOL didGetCompleted = NO;
-		[signal subscribeNext:^(id x) {
+  qck_it(@"should get completed", ^{
+    __block BOOL didGetCompleted = NO;
+    [signal subscribeNext:^(id x) {
 
-		} error:^(NSError *error) {
+    } error:^(NSError *error) {
 
-		} completed:^{
-			didGetCompleted = YES;
-		}];
+    } completed:^{
+      didGetCompleted = YES;
+    }];
 
-		expect(@(didGetCompleted)).to(beTruthy());
-	});
+    expect(@(didGetCompleted)).to(beTruthy());
+  });
 
-	qck_it(@"should not get an error", ^{
-		__block BOOL didGetError = NO;
-		[signal subscribeNext:^(id x) {
+  qck_it(@"should not get an error", ^{
+    __block BOOL didGetError = NO;
+    [signal subscribeNext:^(id x) {
 
-		} error:^(NSError *error) {
-			didGetError = YES;
-		} completed:^{
+    } error:^(NSError *error) {
+      didGetError = YES;
+    } completed:^{
 
-		}];
+    }];
 
-		expect(@(didGetError)).to(beFalsy());
-	});
+    expect(@(didGetError)).to(beFalsy());
+  });
 
-	qck_it(@"shouldn't get anything after dispose", ^{
-		RACTestScheduler *scheduler = [[RACTestScheduler alloc] init];
-		NSMutableArray *receivedValues = [NSMutableArray array];
+  qck_it(@"shouldn't get anything after dispose", ^{
+    RACTestScheduler *scheduler = [[RACTestScheduler alloc] init];
+    NSMutableArray *receivedValues = [NSMutableArray array];
 
-		RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@0];
+    RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@0];
 
-			[scheduler afterDelay:0 schedule:^{
-				[subscriber sendNext:@1];
-			}];
+      [scheduler afterDelay:0 schedule:^{
+        [subscriber sendNext:@1];
+      }];
 
-			return nil;
-		}];
+      return nil;
+    }];
 
-		RACDisposable *disposable = [signal subscribeNext:^(id x) {
-			[receivedValues addObject:x];
-		}];
+    RACDisposable *disposable = [signal subscribeNext:^(id x) {
+      [receivedValues addObject:x];
+    }];
 
-		NSArray *expectedValues = @[ @0 ];
-		expect(receivedValues).to(equal(expectedValues));
+    NSArray *expectedValues = @[ @0 ];
+    expect(receivedValues).to(equal(expectedValues));
 
-		[disposable dispose];
-		[scheduler stepAll];
+    [disposable dispose];
+    [scheduler stepAll];
 
-		expect(receivedValues).to(equal(expectedValues));
-	});
+    expect(receivedValues).to(equal(expectedValues));
+  });
 
-	qck_it(@"should have a current scheduler in didSubscribe block", ^{
-		__block RACScheduler *currentScheduler;
-		RACSignal *signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			currentScheduler = RACScheduler.currentScheduler;
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should have a current scheduler in didSubscribe block", ^{
+    __block RACScheduler *currentScheduler;
+    RACSignal *signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      currentScheduler = RACScheduler.currentScheduler;
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		[signal subscribeNext:^(id x) {}];
-		expect(currentScheduler).notTo(beNil());
+    [signal subscribeNext:^(id x) {}];
+    expect(currentScheduler).notTo(beNil());
 
-		currentScheduler = nil;
-		dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-			[signal subscribeNext:^(id x) {}];
-		});
-		expect(currentScheduler).toEventuallyNot(beNil());
-	});
+    currentScheduler = nil;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+      [signal subscribeNext:^(id x) {}];
+    });
+    expect(currentScheduler).toEventuallyNot(beNil());
+  });
 
-	qck_it(@"should automatically dispose of other subscriptions from +createSignal:", ^{
-		__block BOOL innerDisposed = NO;
-		__block id<RACSubscriber> innerSubscriber = nil;
+  qck_it(@"should automatically dispose of other subscriptions from +createSignal:", ^{
+    __block BOOL innerDisposed = NO;
+    __block id<RACSubscriber> innerSubscriber = nil;
 
-		RACSignal *innerSignal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			// Keep the subscriber alive so it doesn't trigger disposal on dealloc
-			innerSubscriber = subscriber;
-			return [RACDisposable disposableWithBlock:^{
-				innerDisposed = YES;
-			}];
-		}];
+    RACSignal *innerSignal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      // Keep the subscriber alive so it doesn't trigger disposal on dealloc
+      innerSubscriber = subscriber;
+      return [RACDisposable disposableWithBlock:^{
+        innerDisposed = YES;
+      }];
+    }];
 
-		RACSignal *outerSignal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[innerSignal subscribe:subscriber];
-			return nil;
-		}];
+    RACSignal *outerSignal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [innerSignal subscribe:subscriber];
+      return nil;
+    }];
 
-		RACDisposable *disposable = [outerSignal subscribeCompleted:^{}];
-		expect(disposable).notTo(beNil());
-		expect(@(innerDisposed)).to(beFalsy());
+    RACDisposable *disposable = [outerSignal subscribeCompleted:^{}];
+    expect(disposable).notTo(beNil());
+    expect(@(innerDisposed)).to(beFalsy());
 
-		[disposable dispose];
-		expect(@(innerDisposed)).to(beTruthy());
-	});
+    [disposable dispose];
+    expect(@(innerDisposed)).to(beTruthy());
+  });
 });
 
 qck_describe(@"-takeUntil:", ^{
-	qck_it(@"should support value as trigger", ^{
-		__block BOOL shouldBeGettingItems = YES;
-		RACSubject *subject = [RACSubject subject];
-		RACSubject *cutOffSubject = [RACSubject subject];
-		[[subject takeUntil:cutOffSubject] subscribeNext:^(id x) {
-			expect(@(shouldBeGettingItems)).to(beTruthy());
-		}];
+  qck_it(@"should support value as trigger", ^{
+    __block BOOL shouldBeGettingItems = YES;
+    RACSubject *subject = [RACSubject subject];
+    RACSubject *cutOffSubject = [RACSubject subject];
+    [[subject takeUntil:cutOffSubject] subscribeNext:^(id x) {
+      expect(@(shouldBeGettingItems)).to(beTruthy());
+    }];
 
-		shouldBeGettingItems = YES;
-		[subject sendNext:@"test 1"];
-		[subject sendNext:@"test 2"];
+    shouldBeGettingItems = YES;
+    [subject sendNext:@"test 1"];
+    [subject sendNext:@"test 2"];
 
-		[cutOffSubject sendNext:[RACUnit defaultUnit]];
+    [cutOffSubject sendNext:[RACUnit defaultUnit]];
 
-		shouldBeGettingItems = NO;
-		[subject sendNext:@"test 3"];
-	});
+    shouldBeGettingItems = NO;
+    [subject sendNext:@"test 3"];
+  });
 
-	qck_it(@"should support completion as trigger", ^{
-		__block BOOL shouldBeGettingItems = YES;
-		RACSubject *subject = [RACSubject subject];
-		RACSubject *cutOffSubject = [RACSubject subject];
-		[[subject takeUntil:cutOffSubject] subscribeNext:^(id x) {
-			expect(@(shouldBeGettingItems)).to(beTruthy());
-		}];
+  qck_it(@"should support completion as trigger", ^{
+    __block BOOL shouldBeGettingItems = YES;
+    RACSubject *subject = [RACSubject subject];
+    RACSubject *cutOffSubject = [RACSubject subject];
+    [[subject takeUntil:cutOffSubject] subscribeNext:^(id x) {
+      expect(@(shouldBeGettingItems)).to(beTruthy());
+    }];
 
-		[cutOffSubject sendCompleted];
+    [cutOffSubject sendCompleted];
 
-		shouldBeGettingItems = NO;
-		[subject sendNext:@"should not go through"];
-	});
+    shouldBeGettingItems = NO;
+    [subject sendNext:@"should not go through"];
+  });
 
-	qck_it(@"should squelch any values sent immediately upon subscription", ^{
-		RACSignal *valueSignal = [RACSignal return:RACUnit.defaultUnit];
-		RACSignal *cutOffSignal = [RACSignal empty];
+  qck_it(@"should squelch any values sent immediately upon subscription", ^{
+    RACSignal *valueSignal = [RACSignal return:RACUnit.defaultUnit];
+    RACSignal *cutOffSignal = [RACSignal empty];
 
-		__block BOOL gotNext = NO;
-		__block BOOL completed = NO;
+    __block BOOL gotNext = NO;
+    __block BOOL completed = NO;
 
-		[[valueSignal takeUntil:cutOffSignal] subscribeNext:^(id _) {
-			gotNext = YES;
-		} completed:^{
-			completed = YES;
-		}];
+    [[valueSignal takeUntil:cutOffSignal] subscribeNext:^(id _) {
+      gotNext = YES;
+    } completed:^{
+      completed = YES;
+    }];
 
-		expect(@(gotNext)).to(beFalsy());
-		expect(@(completed)).to(beTruthy());
-	});
+    expect(@(gotNext)).to(beFalsy());
+    expect(@(completed)).to(beTruthy());
+  });
 });
 
 qck_describe(@"-takeUntilReplacement:", ^{
-	qck_it(@"should forward values from the receiver until it's replaced", ^{
-		RACSubject *receiver = [RACSubject subject];
-		RACSubject *replacement = [RACSubject subject];
+  qck_it(@"should forward values from the receiver until it's replaced", ^{
+    RACSubject *receiver = [RACSubject subject];
+    RACSubject *replacement = [RACSubject subject];
 
-		NSMutableArray *receivedValues = [NSMutableArray array];
+    NSMutableArray *receivedValues = [NSMutableArray array];
 
-		[[receiver takeUntilReplacement:replacement] subscribeNext:^(id x) {
-			[receivedValues addObject:x];
-		}];
+    [[receiver takeUntilReplacement:replacement] subscribeNext:^(id x) {
+      [receivedValues addObject:x];
+    }];
 
-		expect(receivedValues).to(equal(@[]));
+    expect(receivedValues).to(equal(@[]));
 
-		[receiver sendNext:@1];
-		expect(receivedValues).to(equal(@[ @1 ]));
+    [receiver sendNext:@1];
+    expect(receivedValues).to(equal(@[ @1 ]));
 
-		[receiver sendNext:@2];
-		expect(receivedValues).to(equal((@[ @1, @2 ])));
+    [receiver sendNext:@2];
+    expect(receivedValues).to(equal((@[ @1, @2 ])));
 
-		[replacement sendNext:@3];
-		expect(receivedValues).to(equal((@[ @1, @2, @3 ])));
+    [replacement sendNext:@3];
+    expect(receivedValues).to(equal((@[ @1, @2, @3 ])));
 
-		[receiver sendNext:@4];
-		expect(receivedValues).to(equal((@[ @1, @2, @3 ])));
+    [receiver sendNext:@4];
+    expect(receivedValues).to(equal((@[ @1, @2, @3 ])));
 
-		[replacement sendNext:@5];
-		expect(receivedValues).to(equal((@[ @1, @2, @3, @5 ])));
-	});
+    [replacement sendNext:@5];
+    expect(receivedValues).to(equal((@[ @1, @2, @3, @5 ])));
+  });
 
-	qck_it(@"should forward error from the receiver", ^{
-		RACSubject *receiver = [RACSubject subject];
-		__block BOOL receivedError = NO;
+  qck_it(@"should forward error from the receiver", ^{
+    RACSubject *receiver = [RACSubject subject];
+    __block BOOL receivedError = NO;
 
-		[[receiver takeUntilReplacement:RACSignal.never] subscribeError:^(NSError *error) {
-			receivedError = YES;
-		}];
+    [[receiver takeUntilReplacement:RACSignal.never] subscribeError:^(NSError *error) {
+      receivedError = YES;
+    }];
 
-		[receiver sendError:nil];
-		expect(@(receivedError)).to(beTruthy());
-	});
+    [receiver sendError:nil];
+    expect(@(receivedError)).to(beTruthy());
+  });
 
-	qck_it(@"should not forward completed from the receiver", ^{
-		RACSubject *receiver = [RACSubject subject];
-		__block BOOL receivedCompleted = NO;
+  qck_it(@"should not forward completed from the receiver", ^{
+    RACSubject *receiver = [RACSubject subject];
+    __block BOOL receivedCompleted = NO;
 
-		[[receiver takeUntilReplacement:RACSignal.never] subscribeCompleted: ^{
-			receivedCompleted = YES;
-		}];
+    [[receiver takeUntilReplacement:RACSignal.never] subscribeCompleted: ^{
+      receivedCompleted = YES;
+    }];
 
-		[receiver sendCompleted];
-		expect(@(receivedCompleted)).to(beFalsy());
-	});
+    [receiver sendCompleted];
+    expect(@(receivedCompleted)).to(beFalsy());
+  });
 
-	qck_it(@"should forward error from the replacement signal", ^{
-		RACSubject *replacement = [RACSubject subject];
-		__block BOOL receivedError = NO;
+  qck_it(@"should forward error from the replacement signal", ^{
+    RACSubject *replacement = [RACSubject subject];
+    __block BOOL receivedError = NO;
 
-		[[RACSignal.never takeUntilReplacement:replacement] subscribeError:^(NSError *error) {
-			receivedError = YES;
-		}];
+    [[RACSignal.never takeUntilReplacement:replacement] subscribeError:^(NSError *error) {
+      receivedError = YES;
+    }];
 
-		[replacement sendError:nil];
-		expect(@(receivedError)).to(beTruthy());
-	});
+    [replacement sendError:nil];
+    expect(@(receivedError)).to(beTruthy());
+  });
 
-	qck_it(@"should forward completed from the replacement signal", ^{
-		RACSubject *replacement = [RACSubject subject];
-		__block BOOL receivedCompleted = NO;
+  qck_it(@"should forward completed from the replacement signal", ^{
+    RACSubject *replacement = [RACSubject subject];
+    __block BOOL receivedCompleted = NO;
 
-		[[RACSignal.never takeUntilReplacement:replacement] subscribeCompleted: ^{
-			receivedCompleted = YES;
-		}];
+    [[RACSignal.never takeUntilReplacement:replacement] subscribeCompleted: ^{
+      receivedCompleted = YES;
+    }];
 
-		[replacement sendCompleted];
-		expect(@(receivedCompleted)).to(beTruthy());
-	});
+    [replacement sendCompleted];
+    expect(@(receivedCompleted)).to(beTruthy());
+  });
 
-	qck_it(@"should not forward values from the receiver if both send synchronously", ^{
-		RACSignal *receiver = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@1];
-			[subscriber sendNext:@2];
-			[subscriber sendNext:@3];
-			return nil;
-		}];
-		RACSignal *replacement = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@4];
-			[subscriber sendNext:@5];
-			[subscriber sendNext:@6];
-			return nil;
-		}];
+  qck_it(@"should not forward values from the receiver if both send synchronously", ^{
+    RACSignal *receiver = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@1];
+      [subscriber sendNext:@2];
+      [subscriber sendNext:@3];
+      return nil;
+    }];
+    RACSignal *replacement = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@4];
+      [subscriber sendNext:@5];
+      [subscriber sendNext:@6];
+      return nil;
+    }];
 
-		NSMutableArray *receivedValues = [NSMutableArray array];
+    NSMutableArray *receivedValues = [NSMutableArray array];
 
-		[[receiver takeUntilReplacement:replacement] subscribeNext:^(id x) {
-			[receivedValues addObject:x];
-		}];
+    [[receiver takeUntilReplacement:replacement] subscribeNext:^(id x) {
+      [receivedValues addObject:x];
+    }];
 
-		expect(receivedValues).to(equal((@[ @4, @5, @6 ])));
-	});
+    expect(receivedValues).to(equal((@[ @4, @5, @6 ])));
+  });
 
-	qck_it(@"should dispose of the receiver when it's disposed of", ^{
-		__block BOOL receiverDisposed = NO;
-		RACSignal *receiver = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			return [RACDisposable disposableWithBlock:^{
-				receiverDisposed = YES;
-			}];
-		}];
+  qck_it(@"should dispose of the receiver when it's disposed of", ^{
+    __block BOOL receiverDisposed = NO;
+    RACSignal *receiver = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      return [RACDisposable disposableWithBlock:^{
+        receiverDisposed = YES;
+      }];
+    }];
 
-		[[[receiver takeUntilReplacement:RACSignal.never] subscribeCompleted:^{}] dispose];
+    [[[receiver takeUntilReplacement:RACSignal.never] subscribeCompleted:^{}] dispose];
 
-		expect(@(receiverDisposed)).to(beTruthy());
-	});
+    expect(@(receiverDisposed)).to(beTruthy());
+  });
 
-	qck_it(@"should dispose of the replacement signal when it's disposed of", ^{
-		__block BOOL replacementDisposed = NO;
-		RACSignal *replacement = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			return [RACDisposable disposableWithBlock:^{
-				replacementDisposed = YES;
-			}];
-		}];
+  qck_it(@"should dispose of the replacement signal when it's disposed of", ^{
+    __block BOOL replacementDisposed = NO;
+    RACSignal *replacement = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      return [RACDisposable disposableWithBlock:^{
+        replacementDisposed = YES;
+      }];
+    }];
 
-		[[[RACSignal.never takeUntilReplacement:replacement] subscribeCompleted:^{}] dispose];
+    [[[RACSignal.never takeUntilReplacement:replacement] subscribeCompleted:^{}] dispose];
 
-		expect(@(replacementDisposed)).to(beTruthy());
-	});
+    expect(@(replacementDisposed)).to(beTruthy());
+  });
 
-	qck_it(@"should dispose of the receiver when the replacement signal sends an event", ^{
-		__block BOOL receiverDisposed = NO;
-		__block id<RACSubscriber> receiverSubscriber = nil;
-		RACSignal *receiver = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			// Keep the subscriber alive so it doesn't trigger disposal on dealloc
-			receiverSubscriber = subscriber;
-			return [RACDisposable disposableWithBlock:^{
-				receiverDisposed = YES;
-			}];
-		}];
-		RACSubject *replacement = [RACSubject subject];
+  qck_it(@"should dispose of the receiver when the replacement signal sends an event", ^{
+    __block BOOL receiverDisposed = NO;
+    __block id<RACSubscriber> receiverSubscriber = nil;
+    RACSignal *receiver = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      // Keep the subscriber alive so it doesn't trigger disposal on dealloc
+      receiverSubscriber = subscriber;
+      return [RACDisposable disposableWithBlock:^{
+        receiverDisposed = YES;
+      }];
+    }];
+    RACSubject *replacement = [RACSubject subject];
 
-		[[receiver takeUntilReplacement:replacement] subscribeCompleted:^{}];
+    [[receiver takeUntilReplacement:replacement] subscribeCompleted:^{}];
 
-		expect(@(receiverDisposed)).to(beFalsy());
+    expect(@(receiverDisposed)).to(beFalsy());
 
-		[replacement sendNext:nil];
+    [replacement sendNext:nil];
 
-		expect(@(receiverDisposed)).to(beTruthy());
-	});
+    expect(@(receiverDisposed)).to(beTruthy());
+  });
 });
 
 qck_describe(@"disposal", ^{
-	qck_it(@"should dispose of the didSubscribe disposable", ^{
-		__block BOOL innerDisposed = NO;
-		RACSignal *signal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			return [RACDisposable disposableWithBlock:^{
-				innerDisposed = YES;
-			}];
-		}];
+  qck_it(@"should dispose of the didSubscribe disposable", ^{
+    __block BOOL innerDisposed = NO;
+    RACSignal *signal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      return [RACDisposable disposableWithBlock:^{
+        innerDisposed = YES;
+      }];
+    }];
 
-		expect(@(innerDisposed)).to(beFalsy());
+    expect(@(innerDisposed)).to(beFalsy());
 
-		RACDisposable *disposable = [signal subscribeNext:^(id x) {}];
-		expect(disposable).notTo(beNil());
+    RACDisposable *disposable = [signal subscribeNext:^(id x) {}];
+    expect(disposable).notTo(beNil());
 
-		[disposable dispose];
-		expect(@(innerDisposed)).to(beTruthy());
-	});
+    [disposable dispose];
+    expect(@(innerDisposed)).to(beTruthy());
+  });
 
-	qck_it(@"should dispose of the didSubscribe disposable asynchronously", ^{
-		__block BOOL innerDisposed = NO;
-		RACSignal *signal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			return [RACDisposable disposableWithBlock:^{
-				innerDisposed = YES;
-			}];
-		}];
+  qck_it(@"should dispose of the didSubscribe disposable asynchronously", ^{
+    __block BOOL innerDisposed = NO;
+    RACSignal *signal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      return [RACDisposable disposableWithBlock:^{
+        innerDisposed = YES;
+      }];
+    }];
 
-		[[RACScheduler scheduler] schedule:^{
-			RACDisposable *disposable = [signal subscribeNext:^(id x) {}];
-			[disposable dispose];
-		}];
+    [[RACScheduler scheduler] schedule:^{
+      RACDisposable *disposable = [signal subscribeNext:^(id x) {}];
+      [disposable dispose];
+    }];
 
-		expect(@(innerDisposed)).toEventually(beTruthy());
-	});
+    expect(@(innerDisposed)).toEventually(beTruthy());
+  });
 });
 
 qck_describe(@"querying", ^{
-	__block RACSignal *signal = nil;
-	id nextValueSent = @"1";
+  __block RACSignal *signal = nil;
+  id nextValueSent = @"1";
 
-	qck_beforeEach(^{
-		signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:nextValueSent];
-			[subscriber sendNext:@"other value"];
-			[subscriber sendCompleted];
-			return nil;
-		}];
-	});
+  qck_beforeEach(^{
+    signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:nextValueSent];
+      [subscriber sendNext:@"other value"];
+      [subscriber sendCompleted];
+      return nil;
+    }];
+  });
 
-	qck_it(@"should return first 'next' value with -firstOrDefault:success:error:", ^{
-		RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@1];
-			[subscriber sendNext:@2];
-			[subscriber sendNext:@3];
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should return first 'next' value with -firstOrDefault:success:error:", ^{
+    RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@1];
+      [subscriber sendNext:@2];
+      [subscriber sendNext:@3];
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		expect(signal).notTo(beNil());
+    expect(signal).notTo(beNil());
 
-		__block BOOL success = NO;
-		__block NSError *error = nil;
-		expect([signal firstOrDefault:@5 success:&success error:&error]).to(equal(@1));
-		expect(@(success)).to(beTruthy());
-		expect(error).to(beNil());
-	});
+    __block BOOL success = NO;
+    __block NSError *error = nil;
+    expect([signal firstOrDefault:@5 success:&success error:&error]).to(equal(@1));
+    expect(@(success)).to(beTruthy());
+    expect(error).to(beNil());
+  });
 
-	qck_it(@"should return first default value with -firstOrDefault:success:error:", ^{
-		RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should return first default value with -firstOrDefault:success:error:", ^{
+    RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		expect(signal).notTo(beNil());
+    expect(signal).notTo(beNil());
 
-		__block BOOL success = NO;
-		__block NSError *error = nil;
-		expect([signal firstOrDefault:@5 success:&success error:&error]).to(equal(@5));
-		expect(@(success)).to(beTruthy());
-		expect(error).to(beNil());
-	});
+    __block BOOL success = NO;
+    __block NSError *error = nil;
+    expect([signal firstOrDefault:@5 success:&success error:&error]).to(equal(@5));
+    expect(@(success)).to(beTruthy());
+    expect(error).to(beNil());
+  });
 
-	qck_it(@"should return error with -firstOrDefault:success:error:", ^{
-		RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendError:RACSignalTestError];
-			return nil;
-		}];
+  qck_it(@"should return error with -firstOrDefault:success:error:", ^{
+    RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendError:RACSignalTestError];
+      return nil;
+    }];
 
-		expect(signal).notTo(beNil());
+    expect(signal).notTo(beNil());
 
-		__block BOOL success = NO;
-		__block NSError *error = nil;
-		expect([signal firstOrDefault:@5 success:&success error:&error]).to(equal(@5));
-		expect(@(success)).to(beFalsy());
-		expect(error).to(equal(RACSignalTestError));
-	});
+    __block BOOL success = NO;
+    __block NSError *error = nil;
+    expect([signal firstOrDefault:@5 success:&success error:&error]).to(equal(@5));
+    expect(@(success)).to(beFalsy());
+    expect(error).to(equal(RACSignalTestError));
+  });
 
-	qck_it(@"shouldn't crash when returning an error from a background scheduler", ^{
-		RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[[RACScheduler scheduler] schedule:^{
-				[subscriber sendError:RACSignalTestError];
-			}];
+  qck_it(@"shouldn't crash when returning an error from a background scheduler", ^{
+    RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [[RACScheduler scheduler] schedule:^{
+        [subscriber sendError:RACSignalTestError];
+      }];
 
-			return nil;
-		}];
+      return nil;
+    }];
 
-		expect(signal).notTo(beNil());
+    expect(signal).notTo(beNil());
 
-		__block BOOL success = NO;
-		__block NSError *error = nil;
-		expect([signal firstOrDefault:@5 success:&success error:&error]).to(equal(@5));
-		expect(@(success)).to(beFalsy());
-		expect(error).to(equal(RACSignalTestError));
-	});
+    __block BOOL success = NO;
+    __block NSError *error = nil;
+    expect([signal firstOrDefault:@5 success:&success error:&error]).to(equal(@5));
+    expect(@(success)).to(beFalsy());
+    expect(error).to(equal(RACSignalTestError));
+  });
 
-	qck_it(@"should terminate the subscription after returning from -firstOrDefault:success:error:", ^{
-		__block BOOL disposed = NO;
-		RACSignal *signal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			[subscriber sendNext:RACUnit.defaultUnit];
+  qck_it(@"should terminate the subscription after returning from -firstOrDefault:success:error:", ^{
+    __block BOOL disposed = NO;
+    RACSignal *signal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      [subscriber sendNext:RACUnit.defaultUnit];
 
-			return [RACDisposable disposableWithBlock:^{
-				disposed = YES;
-			}];
-		}];
+      return [RACDisposable disposableWithBlock:^{
+        disposed = YES;
+      }];
+    }];
 
-		expect(signal).notTo(beNil());
-		expect(@(disposed)).to(beFalsy());
+    expect(signal).notTo(beNil());
+    expect(@(disposed)).to(beFalsy());
 
-		expect([signal firstOrDefault:nil success:NULL error:NULL]).to(equal(RACUnit.defaultUnit));
-		expect(@(disposed)).to(beTruthy());
-	});
+    expect([signal firstOrDefault:nil success:NULL error:NULL]).to(equal(RACUnit.defaultUnit));
+    expect(@(disposed)).to(beTruthy());
+  });
 
-	qck_it(@"should return YES from -waitUntilCompleted: when successful", ^{
-		RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:RACUnit.defaultUnit];
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should return YES from -waitUntilCompleted: when successful", ^{
+    RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:RACUnit.defaultUnit];
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		__block NSError *error = nil;
-		expect(@([signal waitUntilCompleted:&error])).to(beTruthy());
-		expect(error).to(beNil());
-	});
+    __block NSError *error = nil;
+    expect(@([signal waitUntilCompleted:&error])).to(beTruthy());
+    expect(error).to(beNil());
+  });
 
-	qck_it(@"should return NO from -waitUntilCompleted: upon error", ^{
-		RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:RACUnit.defaultUnit];
-			[subscriber sendError:RACSignalTestError];
-			return nil;
-		}];
+  qck_it(@"should return NO from -waitUntilCompleted: upon error", ^{
+    RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:RACUnit.defaultUnit];
+      [subscriber sendError:RACSignalTestError];
+      return nil;
+    }];
 
-		__block NSError *error = nil;
-		expect(@([signal waitUntilCompleted:&error])).to(beFalsy());
-		expect(error).to(equal(RACSignalTestError));
-	});
+    __block NSError *error = nil;
+    expect(@([signal waitUntilCompleted:&error])).to(beFalsy());
+    expect(error).to(equal(RACSignalTestError));
+  });
 
-	qck_it(@"should return a delayed value from -asynchronousFirstOrDefault:success:error:", ^{
-		RACSignal *signal = [[RACSignal return:RACUnit.defaultUnit] delay:0];
+  qck_it(@"should return a delayed value from -asynchronousFirstOrDefault:success:error:", ^{
+    RACSignal *signal = [[RACSignal return:RACUnit.defaultUnit] delay:0];
 
-		__block BOOL scheduledBlockRan = NO;
-		[RACScheduler.mainThreadScheduler schedule:^{
-			scheduledBlockRan = YES;
-		}];
+    __block BOOL scheduledBlockRan = NO;
+    [RACScheduler.mainThreadScheduler schedule:^{
+      scheduledBlockRan = YES;
+    }];
 
-		expect(@(scheduledBlockRan)).to(beFalsy());
+    expect(@(scheduledBlockRan)).to(beFalsy());
 
-		BOOL success = NO;
-		NSError *error = nil;
-		id value = [signal asynchronousFirstOrDefault:nil success:&success error:&error];
+    BOOL success = NO;
+    NSError *error = nil;
+    id value = [signal asynchronousFirstOrDefault:nil success:&success error:&error];
 
-		expect(@(scheduledBlockRan)).to(beTruthy());
+    expect(@(scheduledBlockRan)).to(beTruthy());
 
-		expect(value).to(equal(RACUnit.defaultUnit));
-		expect(@(success)).to(beTruthy());
-		expect(error).to(beNil());
-	});
+    expect(value).to(equal(RACUnit.defaultUnit));
+    expect(@(success)).to(beTruthy());
+    expect(error).to(beNil());
+  });
 
-	qck_it(@"should return a default value from -asynchronousFirstOrDefault:success:error:", ^{
-		RACSignal *signal = [[RACSignal error:RACSignalTestError] delay:0];
+  qck_it(@"should return a default value from -asynchronousFirstOrDefault:success:error:", ^{
+    RACSignal *signal = [[RACSignal error:RACSignalTestError] delay:0];
 
-		__block BOOL scheduledBlockRan = NO;
-		[RACScheduler.mainThreadScheduler schedule:^{
-			scheduledBlockRan = YES;
-		}];
+    __block BOOL scheduledBlockRan = NO;
+    [RACScheduler.mainThreadScheduler schedule:^{
+      scheduledBlockRan = YES;
+    }];
 
-		expect(@(scheduledBlockRan)).to(beFalsy());
+    expect(@(scheduledBlockRan)).to(beFalsy());
 
-		BOOL success = NO;
-		NSError *error = nil;
-		id value = [signal asynchronousFirstOrDefault:RACUnit.defaultUnit success:&success error:&error];
+    BOOL success = NO;
+    NSError *error = nil;
+    id value = [signal asynchronousFirstOrDefault:RACUnit.defaultUnit success:&success error:&error];
 
-		expect(@(scheduledBlockRan)).to(beTruthy());
+    expect(@(scheduledBlockRan)).to(beTruthy());
 
-		expect(value).to(equal(RACUnit.defaultUnit));
-		expect(@(success)).to(beFalsy());
-		expect(error).to(equal(RACSignalTestError));
-	});
+    expect(value).to(equal(RACUnit.defaultUnit));
+    expect(@(success)).to(beFalsy());
+    expect(error).to(equal(RACSignalTestError));
+  });
 
-	qck_it(@"should return a delayed error from -asynchronousFirstOrDefault:success:error:", ^{
-		RACSignal *signal = [[RACSignal
-			createSignal:^(id<RACSubscriber> subscriber) {
-				return [[RACScheduler scheduler] schedule:^{
-					[subscriber sendError:RACSignalTestError];
-				}];
-			}]
-			deliverOn:RACScheduler.mainThreadScheduler];
+  qck_it(@"should return a delayed error from -asynchronousFirstOrDefault:success:error:", ^{
+    RACSignal *signal = [[RACSignal
+      createSignal:^(id<RACSubscriber> subscriber) {
+        return [[RACScheduler scheduler] schedule:^{
+          [subscriber sendError:RACSignalTestError];
+        }];
+      }]
+      deliverOn:RACScheduler.mainThreadScheduler];
 
-		__block NSError *error = nil;
-		__block BOOL success = NO;
-		expect([signal asynchronousFirstOrDefault:nil success:&success error:&error]).to(beNil());
+    __block NSError *error = nil;
+    __block BOOL success = NO;
+    expect([signal asynchronousFirstOrDefault:nil success:&success error:&error]).to(beNil());
 
-		expect(@(success)).to(beFalsy());
-		expect(error).to(equal(RACSignalTestError));
-	});
+    expect(@(success)).to(beFalsy());
+    expect(error).to(equal(RACSignalTestError));
+  });
 
-	qck_it(@"should terminate the subscription after returning from -asynchronousFirstOrDefault:success:error:", ^{
-		__block BOOL disposed = NO;
-		RACSignal *signal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			[[RACScheduler scheduler] schedule:^{
-				[subscriber sendNext:RACUnit.defaultUnit];
-			}];
+  qck_it(@"should terminate the subscription after returning from -asynchronousFirstOrDefault:success:error:", ^{
+    __block BOOL disposed = NO;
+    RACSignal *signal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      [[RACScheduler scheduler] schedule:^{
+        [subscriber sendNext:RACUnit.defaultUnit];
+      }];
 
-			return [RACDisposable disposableWithBlock:^{
-				disposed = YES;
-			}];
-		}];
+      return [RACDisposable disposableWithBlock:^{
+        disposed = YES;
+      }];
+    }];
 
-		expect(signal).notTo(beNil());
-		expect(@(disposed)).to(beFalsy());
+    expect(signal).notTo(beNil());
+    expect(@(disposed)).to(beFalsy());
 
-		expect([signal asynchronousFirstOrDefault:nil success:NULL error:NULL]).to(equal(RACUnit.defaultUnit));
-		expect(@(disposed)).toEventually(beTruthy());
-	});
+    expect([signal asynchronousFirstOrDefault:nil success:NULL error:NULL]).to(equal(RACUnit.defaultUnit));
+    expect(@(disposed)).toEventually(beTruthy());
+  });
 
-	qck_it(@"should return a delayed success from -asynchronouslyWaitUntilCompleted:", ^{
-		RACSignal *signal = [[RACSignal return:RACUnit.defaultUnit] delay:0];
+  qck_it(@"should return a delayed success from -asynchronouslyWaitUntilCompleted:", ^{
+    RACSignal *signal = [[RACSignal return:RACUnit.defaultUnit] delay:0];
 
-		__block BOOL scheduledBlockRan = NO;
-		[RACScheduler.mainThreadScheduler schedule:^{
-			scheduledBlockRan = YES;
-		}];
+    __block BOOL scheduledBlockRan = NO;
+    [RACScheduler.mainThreadScheduler schedule:^{
+      scheduledBlockRan = YES;
+    }];
 
-		expect(@(scheduledBlockRan)).to(beFalsy());
+    expect(@(scheduledBlockRan)).to(beFalsy());
 
-		NSError *error = nil;
-		BOOL success = [signal asynchronouslyWaitUntilCompleted:&error];
+    NSError *error = nil;
+    BOOL success = [signal asynchronouslyWaitUntilCompleted:&error];
 
-		expect(@(scheduledBlockRan)).to(beTruthy());
+    expect(@(scheduledBlockRan)).to(beTruthy());
 
-		expect(@(success)).to(beTruthy());
-		expect(error).to(beNil());
-	});
+    expect(@(success)).to(beTruthy());
+    expect(error).to(beNil());
+  });
 });
 
 qck_describe(@"continuation", ^{
-	qck_it(@"should repeat after completion", ^{
-		__block NSUInteger numberOfSubscriptions = 0;
-		RACScheduler *scheduler = [RACScheduler scheduler];
+  qck_it(@"should repeat after completion", ^{
+    __block NSUInteger numberOfSubscriptions = 0;
+    RACScheduler *scheduler = [RACScheduler scheduler];
 
-		RACSignal *signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			return [scheduler schedule:^{
-				if (numberOfSubscriptions == 3) {
-					[subscriber sendError:RACSignalTestError];
-					return;
-				}
+    RACSignal *signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      return [scheduler schedule:^{
+        if (numberOfSubscriptions == 3) {
+          [subscriber sendError:RACSignalTestError];
+          return;
+        }
 
-				numberOfSubscriptions++;
+        numberOfSubscriptions++;
 
-				[subscriber sendNext:@"1"];
-				[subscriber sendCompleted];
-				[subscriber sendError:RACSignalTestError];
-			}];
-		}];
+        [subscriber sendNext:@"1"];
+        [subscriber sendCompleted];
+        [subscriber sendError:RACSignalTestError];
+      }];
+    }];
 
-		__block NSUInteger nextCount = 0;
-		__block BOOL gotCompleted = NO;
-		[[signal repeat] subscribeNext:^(id x) {
-			nextCount++;
-		} error:^(NSError *error) {
+    __block NSUInteger nextCount = 0;
+    __block BOOL gotCompleted = NO;
+    [[signal repeat] subscribeNext:^(id x) {
+      nextCount++;
+    } error:^(NSError *error) {
 
-		} completed:^{
-			gotCompleted = YES;
-		}];
+    } completed:^{
+      gotCompleted = YES;
+    }];
 
-		expect(@(nextCount)).toEventually(equal(@3));
-		expect(@(gotCompleted)).to(beFalsy());
-	});
+    expect(@(nextCount)).toEventually(equal(@3));
+    expect(@(gotCompleted)).to(beFalsy());
+  });
 
-	qck_it(@"should stop repeating when disposed", ^{
-		RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@1];
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should stop repeating when disposed", ^{
+    RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@1];
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		NSMutableArray *values = [NSMutableArray array];
+    NSMutableArray *values = [NSMutableArray array];
 
-		__block BOOL completed = NO;
-		__block RACDisposable *disposable = [[[signal
-			repeat]
-			subscribeOn:RACScheduler.mainThreadScheduler]
-			subscribeNext:^(id x) {
-				[values addObject:x];
-				[disposable dispose];
-			} completed:^{
-				completed = YES;
-			}];
+    __block BOOL completed = NO;
+    __block RACDisposable *disposable = [[[signal
+      repeat]
+      subscribeOn:RACScheduler.mainThreadScheduler]
+      subscribeNext:^(id x) {
+        [values addObject:x];
+        [disposable dispose];
+      } completed:^{
+        completed = YES;
+      }];
 
-		expect(values).toEventually(equal(@[ @1 ]));
-		expect(@(completed)).to(beFalsy());
-	});
+    expect(values).toEventually(equal(@[ @1 ]));
+    expect(@(completed)).to(beFalsy());
+  });
 
-	qck_it(@"should stop repeating when disposed by -take:", ^{
-		RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@1];
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should stop repeating when disposed by -take:", ^{
+    RACSignal *signal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@1];
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		NSMutableArray *values = [NSMutableArray array];
+    NSMutableArray *values = [NSMutableArray array];
 
-		__block BOOL completed = NO;
-		[[[signal repeat] take:1] subscribeNext:^(id x) {
-			[values addObject:x];
-		} completed:^{
-			completed = YES;
-		}];
+    __block BOOL completed = NO;
+    [[[signal repeat] take:1] subscribeNext:^(id x) {
+      [values addObject:x];
+    } completed:^{
+      completed = YES;
+    }];
 
-		expect(values).toEventually(equal(@[ @1 ]));
-		expect(@(completed)).to(beTruthy());
-	});
+    expect(values).toEventually(equal(@[ @1 ]));
+    expect(@(completed)).to(beTruthy());
+  });
 });
 
 qck_describe(@"+combineLatestWith:", ^{
-	__block RACSubject *subject1 = nil;
-	__block RACSubject *subject2 = nil;
-	__block RACSignal *combined = nil;
+  __block RACSubject *subject1 = nil;
+  __block RACSubject *subject2 = nil;
+  __block RACSignal *combined = nil;
 
-	qck_beforeEach(^{
-		subject1 = [RACSubject subject];
-		subject2 = [RACSubject subject];
-		combined = [RACSignal combineLatest:@[ subject1, subject2 ]];
-	});
+  qck_beforeEach(^{
+    subject1 = [RACSubject subject];
+    subject2 = [RACSubject subject];
+    combined = [RACSignal combineLatest:@[ subject1, subject2 ]];
+  });
 
-	qck_it(@"should send next only once both signals send next", ^{
-		__block RACTuple *tuple;
+  qck_it(@"should send next only once both signals send next", ^{
+    __block RACTuple *tuple;
 
-		[combined subscribeNext:^(id x) {
-			tuple = x;
-		}];
+    [combined subscribeNext:^(id x) {
+      tuple = x;
+    }];
 
-		expect(tuple).to(beNil());
+    expect(tuple).to(beNil());
 
-		[subject1 sendNext:@"1"];
-		expect(tuple).to(beNil());
+    [subject1 sendNext:@"1"];
+    expect(tuple).to(beNil());
 
-		[subject2 sendNext:@"2"];
-		expect(tuple).to(equal(RACTuplePack(@"1", @"2")));
-	});
+    [subject2 sendNext:@"2"];
+    expect(tuple).to(equal(RACTuplePack(@"1", @"2")));
+  });
 
-	qck_it(@"should send nexts when either signal sends multiple times", ^{
-		NSMutableArray *results = [NSMutableArray array];
-		[combined subscribeNext:^(id x) {
-			[results addObject:x];
-		}];
+  qck_it(@"should send nexts when either signal sends multiple times", ^{
+    NSMutableArray *results = [NSMutableArray array];
+    [combined subscribeNext:^(id x) {
+      [results addObject:x];
+    }];
 
-		[subject1 sendNext:@"1"];
-		[subject2 sendNext:@"2"];
+    [subject1 sendNext:@"1"];
+    [subject2 sendNext:@"2"];
 
-		[subject1 sendNext:@"3"];
-		[subject2 sendNext:@"4"];
+    [subject1 sendNext:@"3"];
+    [subject2 sendNext:@"4"];
 
-		expect(results[0]).to(equal(RACTuplePack(@"1", @"2")));
-		expect(results[1]).to(equal(RACTuplePack(@"3", @"2")));
-		expect(results[2]).to(equal(RACTuplePack(@"3", @"4")));
-	});
+    expect(results[0]).to(equal(RACTuplePack(@"1", @"2")));
+    expect(results[1]).to(equal(RACTuplePack(@"3", @"2")));
+    expect(results[2]).to(equal(RACTuplePack(@"3", @"4")));
+  });
 
-	qck_it(@"should complete when only both signals complete", ^{
-		__block BOOL completed = NO;
+  qck_it(@"should complete when only both signals complete", ^{
+    __block BOOL completed = NO;
 
-		[combined subscribeCompleted:^{
-			completed = YES;
-		}];
+    [combined subscribeCompleted:^{
+      completed = YES;
+    }];
 
-		expect(@(completed)).to(beFalsy());
+    expect(@(completed)).to(beFalsy());
 
-		[subject1 sendCompleted];
-		expect(@(completed)).to(beFalsy());
+    [subject1 sendCompleted];
+    expect(@(completed)).to(beFalsy());
 
-		[subject2 sendCompleted];
-		expect(@(completed)).to(beTruthy());
-	});
+    [subject2 sendCompleted];
+    expect(@(completed)).to(beTruthy());
+  });
 
-	qck_it(@"should error when either signal errors", ^{
-		__block NSError *receivedError = nil;
-		[combined subscribeError:^(NSError *error) {
-			receivedError = error;
-		}];
+  qck_it(@"should error when either signal errors", ^{
+    __block NSError *receivedError = nil;
+    [combined subscribeError:^(NSError *error) {
+      receivedError = error;
+    }];
 
-		[subject1 sendError:RACSignalTestError];
-		expect(receivedError).to(equal(RACSignalTestError));
-	});
+    [subject1 sendError:RACSignalTestError];
+    expect(receivedError).to(equal(RACSignalTestError));
+  });
 
-	qck_it(@"shouldn't create a retain cycle", ^{
-		__block BOOL subjectDeallocd = NO;
-		__block BOOL signalDeallocd = NO;
+  qck_it(@"shouldn't create a retain cycle", ^{
+    __block BOOL subjectDeallocd = NO;
+    __block BOOL signalDeallocd = NO;
 
-		@autoreleasepool {
-			RACSubject *subject __attribute__((objc_precise_lifetime)) = [RACSubject subject];
-			[subject.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-				subjectDeallocd = YES;
-			}]];
+    @autoreleasepool {
+      RACSubject *subject __attribute__((objc_precise_lifetime)) = [RACSubject subject];
+      [subject.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+        subjectDeallocd = YES;
+      }]];
 
-			RACSignal *signal __attribute__((objc_precise_lifetime)) = [RACSignal combineLatest:@[ subject ]];
-			[signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-				signalDeallocd = YES;
-			}]];
+      RACSignal *signal __attribute__((objc_precise_lifetime)) = [RACSignal combineLatest:@[ subject ]];
+      [signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+        signalDeallocd = YES;
+      }]];
 
-			[signal subscribeCompleted:^{}];
-			[subject sendCompleted];
-		}
+      [signal subscribeCompleted:^{}];
+      [subject sendCompleted];
+    }
 
-		expect(@(subjectDeallocd)).toEventually(beTruthy());
-		expect(@(signalDeallocd)).toEventually(beTruthy());
-	});
+    expect(@(subjectDeallocd)).toEventually(beTruthy());
+    expect(@(signalDeallocd)).toEventually(beTruthy());
+  });
 
-	qck_it(@"should combine the same signal", ^{
-		RACSignal *combined = [subject1 combineLatestWith:subject1];
+  qck_it(@"should combine the same signal", ^{
+    RACSignal *combined = [subject1 combineLatestWith:subject1];
 
-		__block RACTuple *tuple;
-		[combined subscribeNext:^(id x) {
-			tuple = x;
-		}];
+    __block RACTuple *tuple;
+    [combined subscribeNext:^(id x) {
+      tuple = x;
+    }];
 
-		[subject1 sendNext:@"foo"];
-		expect(tuple).to(equal(RACTuplePack(@"foo", @"foo")));
+    [subject1 sendNext:@"foo"];
+    expect(tuple).to(equal(RACTuplePack(@"foo", @"foo")));
 
-		[subject1 sendNext:@"bar"];
-		expect(tuple).to(equal(RACTuplePack(@"bar", @"bar")));
-	});
+    [subject1 sendNext:@"bar"];
+    expect(tuple).to(equal(RACTuplePack(@"bar", @"bar")));
+  });
 
-	qck_it(@"should combine the same side-effecting signal", ^{
-		__block NSUInteger counter = 0;
-		RACSignal *sideEffectingSignal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@(++counter)];
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should combine the same side-effecting signal", ^{
+    __block NSUInteger counter = 0;
+    RACSignal *sideEffectingSignal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@(++counter)];
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		RACSignal *combined = [sideEffectingSignal combineLatestWith:sideEffectingSignal];
-		expect(@(counter)).to(equal(@0));
+    RACSignal *combined = [sideEffectingSignal combineLatestWith:sideEffectingSignal];
+    expect(@(counter)).to(equal(@0));
 
-		NSMutableArray *receivedValues = [NSMutableArray array];
-		[combined subscribeNext:^(id x) {
-			[receivedValues addObject:x];
-		}];
+    NSMutableArray *receivedValues = [NSMutableArray array];
+    [combined subscribeNext:^(id x) {
+      [receivedValues addObject:x];
+    }];
 
-		expect(@(counter)).to(equal(@2));
+    expect(@(counter)).to(equal(@2));
 
-		NSArray *expected = @[ RACTuplePack(@1, @2) ];
-		expect(receivedValues).to(equal(expected));
-	});
+    NSArray *expected = @[ RACTuplePack(@1, @2) ];
+    expect(receivedValues).to(equal(expected));
+  });
 });
 
 qck_describe(@"+combineLatest:", ^{
-	qck_it(@"should return tuples even when only combining one signal", ^{
-		RACSubject *subject = [RACSubject subject];
+  qck_it(@"should return tuples even when only combining one signal", ^{
+    RACSubject *subject = [RACSubject subject];
 
-		__block RACTuple *tuple;
-		[[RACSignal combineLatest:@[ subject ]] subscribeNext:^(id x) {
-			tuple = x;
-		}];
+    __block RACTuple *tuple;
+    [[RACSignal combineLatest:@[ subject ]] subscribeNext:^(id x) {
+      tuple = x;
+    }];
 
-		[subject sendNext:@"foo"];
-		expect(tuple).to(equal(RACTuplePack(@"foo")));
-	});
+    [subject sendNext:@"foo"];
+    expect(tuple).to(equal(RACTuplePack(@"foo")));
+  });
 
-	qck_it(@"should complete immediately when not given any signals", ^{
-		RACSignal *signal = [RACSignal combineLatest:@[]];
+  qck_it(@"should complete immediately when not given any signals", ^{
+    RACSignal *signal = [RACSignal combineLatest:@[]];
 
-		__block BOOL completed = NO;
-		[signal subscribeCompleted:^{
-			completed = YES;
-		}];
+    __block BOOL completed = NO;
+    [signal subscribeCompleted:^{
+      completed = YES;
+    }];
 
-		expect(@(completed)).to(beTruthy());
-	});
+    expect(@(completed)).to(beTruthy());
+  });
 
-	qck_it(@"should only complete after all its signals complete", ^{
-		RACSubject *subject1 = [RACSubject subject];
-		RACSubject *subject2 = [RACSubject subject];
-		RACSubject *subject3 = [RACSubject subject];
-		RACSignal *combined = [RACSignal combineLatest:@[ subject1, subject2, subject3 ]];
+  qck_it(@"should only complete after all its signals complete", ^{
+    RACSubject *subject1 = [RACSubject subject];
+    RACSubject *subject2 = [RACSubject subject];
+    RACSubject *subject3 = [RACSubject subject];
+    RACSignal *combined = [RACSignal combineLatest:@[ subject1, subject2, subject3 ]];
 
-		__block BOOL completed = NO;
-		[combined subscribeCompleted:^{
-			completed = YES;
-		}];
+    __block BOOL completed = NO;
+    [combined subscribeCompleted:^{
+      completed = YES;
+    }];
 
-		expect(@(completed)).to(beFalsy());
+    expect(@(completed)).to(beFalsy());
 
-		[subject1 sendCompleted];
-		expect(@(completed)).to(beFalsy());
+    [subject1 sendCompleted];
+    expect(@(completed)).to(beFalsy());
 
-		[subject2 sendCompleted];
-		expect(@(completed)).to(beFalsy());
+    [subject2 sendCompleted];
+    expect(@(completed)).to(beFalsy());
 
-		[subject3 sendCompleted];
-		expect(@(completed)).to(beTruthy());
-	});
+    [subject3 sendCompleted];
+    expect(@(completed)).to(beTruthy());
+  });
 });
 
 qck_describe(@"+combineLatest:reduce:", ^{
-	__block RACSubject *subject1;
-	__block RACSubject *subject2;
-	__block RACSubject *subject3;
+  __block RACSubject *subject1;
+  __block RACSubject *subject2;
+  __block RACSubject *subject3;
 
-	qck_beforeEach(^{
-		subject1 = [RACSubject subject];
-		subject2 = [RACSubject subject];
-		subject3 = [RACSubject subject];
-	});
+  qck_beforeEach(^{
+    subject1 = [RACSubject subject];
+    subject2 = [RACSubject subject];
+    subject3 = [RACSubject subject];
+  });
 
-	qck_it(@"should send nils for nil values", ^{
-		__block id receivedVal1;
-		__block id receivedVal2;
-		__block id receivedVal3;
+  qck_it(@"should send nils for nil values", ^{
+    __block id receivedVal1;
+    __block id receivedVal2;
+    __block id receivedVal3;
 
-		RACSignal *combined = [RACSignal combineLatest:@[ subject1, subject2, subject3 ] reduce:^ id (id val1, id val2, id val3) {
-			receivedVal1 = val1;
-			receivedVal2 = val2;
-			receivedVal3 = val3;
-			return nil;
-		}];
+    RACSignal *combined = [RACSignal combineLatest:@[ subject1, subject2, subject3 ] reduce:^ id (id val1, id val2, id val3) {
+      receivedVal1 = val1;
+      receivedVal2 = val2;
+      receivedVal3 = val3;
+      return nil;
+    }];
 
-		__block BOOL gotValue = NO;
-		[combined subscribeNext:^(id x) {
-			gotValue = YES;
-		}];
+    __block BOOL gotValue = NO;
+    [combined subscribeNext:^(id x) {
+      gotValue = YES;
+    }];
 
-		[subject1 sendNext:nil];
-		[subject2 sendNext:nil];
-		[subject3 sendNext:nil];
+    [subject1 sendNext:nil];
+    [subject2 sendNext:nil];
+    [subject3 sendNext:nil];
 
-		expect(@(gotValue)).to(beTruthy());
-		expect(receivedVal1).to(beNil());
-		expect(receivedVal2).to(beNil());
-		expect(receivedVal3).to(beNil());
-	});
+    expect(@(gotValue)).to(beTruthy());
+    expect(receivedVal1).to(beNil());
+    expect(receivedVal2).to(beNil());
+    expect(receivedVal3).to(beNil());
+  });
 
-	qck_it(@"should send the return result of the reduce block", ^{
-		RACSignal *combined = [RACSignal combineLatest:@[ subject1, subject2, subject3 ] reduce:^(NSString *string1, NSString *string2, NSString *string3) {
-			return [NSString stringWithFormat:@"%@: %@%@", string1, string2, string3];
-		}];
+  qck_it(@"should send the return result of the reduce block", ^{
+    RACSignal *combined = [RACSignal combineLatest:@[ subject1, subject2, subject3 ] reduce:^(NSString *string1, NSString *string2, NSString *string3) {
+      return [NSString stringWithFormat:@"%@: %@%@", string1, string2, string3];
+    }];
 
-		__block id received;
-		[combined subscribeNext:^(id x) {
-			received = x;
-		}];
+    __block id received;
+    [combined subscribeNext:^(id x) {
+      received = x;
+    }];
 
-		[subject1 sendNext:@"hello"];
-		[subject2 sendNext:@"world"];
-		[subject3 sendNext:@"!!1"];
+    [subject1 sendNext:@"hello"];
+    [subject2 sendNext:@"world"];
+    [subject3 sendNext:@"!!1"];
 
-		expect(received).to(equal(@"hello: world!!1"));
-	});
+    expect(received).to(equal(@"hello: world!!1"));
+  });
 
-	qck_it(@"should handle multiples of the same signals", ^{
-		RACSignal *combined = [RACSignal combineLatest:@[ subject1, subject2, subject1, subject3 ] reduce:^(NSString *string1, NSString *string2, NSString *string3, NSString *string4) {
-			return [NSString stringWithFormat:@"%@ : %@ = %@ : %@", string1, string2, string3, string4];
-		}];
+  qck_it(@"should handle multiples of the same signals", ^{
+    RACSignal *combined = [RACSignal combineLatest:@[ subject1, subject2, subject1, subject3 ] reduce:^(NSString *string1, NSString *string2, NSString *string3, NSString *string4) {
+      return [NSString stringWithFormat:@"%@ : %@ = %@ : %@", string1, string2, string3, string4];
+    }];
 
-		NSMutableArray *receivedValues = NSMutableArray.array;
+    NSMutableArray *receivedValues = NSMutableArray.array;
 
-		[combined subscribeNext:^(id x) {
-			[receivedValues addObject:x];
-		}];
+    [combined subscribeNext:^(id x) {
+      [receivedValues addObject:x];
+    }];
 
-		[subject1 sendNext:@"apples"];
-		expect(receivedValues.lastObject).to(beNil());
+    [subject1 sendNext:@"apples"];
+    expect(receivedValues.lastObject).to(beNil());
 
-		[subject2 sendNext:@"oranges"];
-		expect(receivedValues.lastObject).to(beNil());
+    [subject2 sendNext:@"oranges"];
+    expect(receivedValues.lastObject).to(beNil());
 
-		[subject3 sendNext:@"cattle"];
-		expect(receivedValues.lastObject).to(equal(@"apples : oranges = apples : cattle"));
+    [subject3 sendNext:@"cattle"];
+    expect(receivedValues.lastObject).to(equal(@"apples : oranges = apples : cattle"));
 
-		[subject1 sendNext:@"horses"];
-		expect(receivedValues.lastObject).to(equal(@"horses : oranges = horses : cattle"));
-	});
+    [subject1 sendNext:@"horses"];
+    expect(receivedValues.lastObject).to(equal(@"horses : oranges = horses : cattle"));
+  });
 
-	qck_it(@"should handle multiples of the same side-effecting signal", ^{
-		__block NSUInteger counter = 0;
-		RACSignal *sideEffectingSignal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@(++counter)];
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should handle multiples of the same side-effecting signal", ^{
+    __block NSUInteger counter = 0;
+    RACSignal *sideEffectingSignal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@(++counter)];
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		RACSignal *combined = [RACSignal combineLatest:@[ sideEffectingSignal, sideEffectingSignal, sideEffectingSignal ] reduce:^(id x, id y, id z) {
-			return [NSString stringWithFormat:@"%@%@%@", x, y, z];
-		}];
+    RACSignal *combined = [RACSignal combineLatest:@[ sideEffectingSignal, sideEffectingSignal, sideEffectingSignal ] reduce:^(id x, id y, id z) {
+      return [NSString stringWithFormat:@"%@%@%@", x, y, z];
+    }];
 
-		NSMutableArray *receivedValues = [NSMutableArray array];
-		expect(@(counter)).to(equal(@0));
+    NSMutableArray *receivedValues = [NSMutableArray array];
+    expect(@(counter)).to(equal(@0));
 
-		[combined subscribeNext:^(id x) {
-			[receivedValues addObject:x];
-		}];
+    [combined subscribeNext:^(id x) {
+      [receivedValues addObject:x];
+    }];
 
-		expect(@(counter)).to(equal(@3));
-		expect(receivedValues).to(equal(@[ @"123" ]));
-	});
+    expect(@(counter)).to(equal(@3));
+    expect(receivedValues).to(equal(@[ @"123" ]));
+  });
 });
 
 qck_describe(@"distinctUntilChanged", ^{
-	qck_it(@"should only send values that are distinct from the previous value", ^{
-		RACSignal *sub = [[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@1];
-			[subscriber sendNext:@2];
-			[subscriber sendNext:@2];
-			[subscriber sendNext:@1];
-			[subscriber sendNext:@1];
-			[subscriber sendCompleted];
-			return nil;
-		}] distinctUntilChanged];
+  qck_it(@"should only send values that are distinct from the previous value", ^{
+    RACSignal *sub = [[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@1];
+      [subscriber sendNext:@2];
+      [subscriber sendNext:@2];
+      [subscriber sendNext:@1];
+      [subscriber sendNext:@1];
+      [subscriber sendCompleted];
+      return nil;
+    }] distinctUntilChanged];
 
-		NSArray *values = sub.toArray;
-		NSArray *expected = @[ @1, @2, @1 ];
-		expect(values).to(equal(expected));
-	});
+    NSArray *values = sub.toArray;
+    NSArray *expected = @[ @1, @2, @1 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"shouldn't consider nils to always be distinct", ^{
-		RACSignal *sub = [[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@1];
-			[subscriber sendNext:nil];
-			[subscriber sendNext:nil];
-			[subscriber sendNext:nil];
-			[subscriber sendNext:@1];
-			[subscriber sendCompleted];
-			return nil;
-		}] distinctUntilChanged];
+  qck_it(@"shouldn't consider nils to always be distinct", ^{
+    RACSignal *sub = [[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@1];
+      [subscriber sendNext:nil];
+      [subscriber sendNext:nil];
+      [subscriber sendNext:nil];
+      [subscriber sendNext:@1];
+      [subscriber sendCompleted];
+      return nil;
+    }] distinctUntilChanged];
 
-		NSArray *values = sub.toArray;
-		NSArray *expected = @[ @1, [NSNull null], @1 ];
-		expect(values).to(equal(expected));
-	});
+    NSArray *values = sub.toArray;
+    NSArray *expected = @[ @1, [NSNull null], @1 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"should consider initial nil to be distinct", ^{
-		RACSignal *sub = [[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:nil];
-			[subscriber sendNext:nil];
-			[subscriber sendNext:@1];
-			[subscriber sendCompleted];
-			return nil;
-		}] distinctUntilChanged];
+  qck_it(@"should consider initial nil to be distinct", ^{
+    RACSignal *sub = [[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:nil];
+      [subscriber sendNext:nil];
+      [subscriber sendNext:@1];
+      [subscriber sendCompleted];
+      return nil;
+    }] distinctUntilChanged];
 
-		NSArray *values = sub.toArray;
-		NSArray *expected = @[ [NSNull null], @1 ];
-		expect(values).to(equal(expected));
-	});
+    NSArray *values = sub.toArray;
+    NSArray *expected = @[ [NSNull null], @1 ];
+    expect(values).to(equal(expected));
+  });
 });
 
 qck_describe(@"RACObserve", ^{
-	__block RACTestObject *testObject;
+  __block RACTestObject *testObject;
 
-	qck_beforeEach(^{
-		testObject = [[RACTestObject alloc] init];
-	});
+  qck_beforeEach(^{
+    testObject = [[RACTestObject alloc] init];
+  });
 
-	qck_it(@"should work with object properties", ^{
-		NSArray *expected = @[ @"hello", @"world" ];
-		testObject.objectValue = expected[0];
+  qck_it(@"should work with object properties", ^{
+    NSArray *expected = @[ @"hello", @"world" ];
+    testObject.objectValue = expected[0];
 
-		NSMutableArray *valuesReceived = [NSMutableArray array];
-		[RACObserve(testObject, objectValue) subscribeNext:^(id x) {
-			[valuesReceived addObject:x];
-		}];
+    NSMutableArray *valuesReceived = [NSMutableArray array];
+    [RACObserve(testObject, objectValue) subscribeNext:^(id x) {
+      [valuesReceived addObject:x];
+    }];
 
-		testObject.objectValue = expected[1];
+    testObject.objectValue = expected[1];
 
-		expect(valuesReceived).to(equal(expected));
-	});
+    expect(valuesReceived).to(equal(expected));
+  });
 
-	qck_it(@"should work with non-object properties", ^{
-		NSArray *expected = @[ @42, @43 ];
-		testObject.integerValue = [expected[0] integerValue];
+  qck_it(@"should work with non-object properties", ^{
+    NSArray *expected = @[ @42, @43 ];
+    testObject.integerValue = [expected[0] integerValue];
 
-		NSMutableArray *valuesReceived = [NSMutableArray array];
-		[RACObserve(testObject, integerValue) subscribeNext:^(id x) {
-			[valuesReceived addObject:x];
-		}];
+    NSMutableArray *valuesReceived = [NSMutableArray array];
+    [RACObserve(testObject, integerValue) subscribeNext:^(id x) {
+      [valuesReceived addObject:x];
+    }];
 
-		testObject.integerValue = [expected[1] integerValue];
+    testObject.integerValue = [expected[1] integerValue];
 
-		expect(valuesReceived).to(equal(expected));
-	});
+    expect(valuesReceived).to(equal(expected));
+  });
 
-	qck_it(@"should read the initial value upon subscription", ^{
-		testObject.objectValue = @"foo";
+  qck_it(@"should read the initial value upon subscription", ^{
+    testObject.objectValue = @"foo";
 
-		RACSignal *signal = RACObserve(testObject, objectValue);
-		testObject.objectValue = @"bar";
+    RACSignal *signal = RACObserve(testObject, objectValue);
+    testObject.objectValue = @"bar";
 
-		expect([signal first]).to(equal(@"bar"));
-	});
+    expect([signal first]).to(equal(@"bar"));
+  });
 });
 
 qck_describe(@"-setKeyPath:onObject:", ^{
-	id setupBlock = ^(RACTestObject *testObject, NSString *keyPath, id nilValue, RACSignal *signal) {
-		[signal setKeyPath:keyPath onObject:testObject nilValue:nilValue];
-	};
+  id setupBlock = ^(RACTestObject *testObject, NSString *keyPath, id nilValue, RACSignal *signal) {
+    [signal setKeyPath:keyPath onObject:testObject nilValue:nilValue];
+  };
 
-	qck_itBehavesLike(RACPropertySignalExamples, ^{
-		return @{ RACPropertySignalExamplesSetupBlock: setupBlock };
-	});
+  qck_itBehavesLike(RACPropertySignalExamples, ^{
+    return @{ RACPropertySignalExamplesSetupBlock: setupBlock };
+  });
 
-	qck_it(@"shouldn't send values to dealloc'd objects", ^{
-		RACSubject *subject = [RACSubject subject];
-		@autoreleasepool {
-			RACTestObject *testObject __attribute__((objc_precise_lifetime)) = [[RACTestObject alloc] init];
-			[subject setKeyPath:@keypath(testObject.objectValue) onObject:testObject];
-			expect(testObject.objectValue).to(beNil());
+  qck_it(@"shouldn't send values to dealloc'd objects", ^{
+    RACSubject *subject = [RACSubject subject];
+    @autoreleasepool {
+      RACTestObject *testObject __attribute__((objc_precise_lifetime)) = [[RACTestObject alloc] init];
+      [subject setKeyPath:@keypath(testObject.objectValue) onObject:testObject];
+      expect(testObject.objectValue).to(beNil());
 
-			[subject sendNext:@1];
-			expect(testObject.objectValue).to(equal(@1));
+      [subject sendNext:@1];
+      expect(testObject.objectValue).to(equal(@1));
 
-			[subject sendNext:@2];
-			expect(testObject.objectValue).to(equal(@2));
-		}
+      [subject sendNext:@2];
+      expect(testObject.objectValue).to(equal(@2));
+    }
 
-		// This shouldn't do anything.
-		[subject sendNext:@3];
-	});
+    // This shouldn't do anything.
+    [subject sendNext:@3];
+  });
 
-	qck_it(@"should allow a new derivation after the signal's completed", ^{
-		RACSubject *subject1 = [RACSubject subject];
-		RACTestObject *testObject = [[RACTestObject alloc] init];
-		[subject1 setKeyPath:@keypath(testObject.objectValue) onObject:testObject];
-		[subject1 sendCompleted];
+  qck_it(@"should allow a new derivation after the signal's completed", ^{
+    RACSubject *subject1 = [RACSubject subject];
+    RACTestObject *testObject = [[RACTestObject alloc] init];
+    [subject1 setKeyPath:@keypath(testObject.objectValue) onObject:testObject];
+    [subject1 sendCompleted];
 
-		RACSubject *subject2 = [RACSubject subject];
-		// This will assert if the previous completion didn't dispose of the
-		// subscription.
-		[subject2 setKeyPath:@keypath(testObject.objectValue) onObject:testObject];
-	});
+    RACSubject *subject2 = [RACSubject subject];
+    // This will assert if the previous completion didn't dispose of the
+    // subscription.
+    [subject2 setKeyPath:@keypath(testObject.objectValue) onObject:testObject];
+  });
 
-	qck_it(@"should set the given value when nil is received", ^{
-		RACSubject *subject = [RACSubject subject];
-		RACTestObject *testObject = [[RACTestObject alloc] init];
-		[subject setKeyPath:@keypath(testObject.integerValue) onObject:testObject nilValue:@5];
+  qck_it(@"should set the given value when nil is received", ^{
+    RACSubject *subject = [RACSubject subject];
+    RACTestObject *testObject = [[RACTestObject alloc] init];
+    [subject setKeyPath:@keypath(testObject.integerValue) onObject:testObject nilValue:@5];
 
-		[subject sendNext:@1];
-		expect(@(testObject.integerValue)).to(equal(@1));
+    [subject sendNext:@1];
+    expect(@(testObject.integerValue)).to(equal(@1));
 
-		[subject sendNext:nil];
-		expect(@(testObject.integerValue)).to(equal(@5));
+    [subject sendNext:nil];
+    expect(@(testObject.integerValue)).to(equal(@5));
 
-		[subject sendCompleted];
-		expect(@(testObject.integerValue)).to(equal(@5));
-	});
+    [subject sendCompleted];
+    expect(@(testObject.integerValue)).to(equal(@5));
+  });
 
-	qck_it(@"should keep object alive over -sendNext:", ^{
-		RACSubject *subject = [RACSubject subject];
-		__block RACTestObject *testObject = [[RACTestObject alloc] init];
-		__block id deallocValue;
+  qck_it(@"should keep object alive over -sendNext:", ^{
+    RACSubject *subject = [RACSubject subject];
+    __block RACTestObject *testObject = [[RACTestObject alloc] init];
+    __block id deallocValue;
 
-		__unsafe_unretained RACTestObject *unsafeTestObject = testObject;
-		[testObject.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-			deallocValue = unsafeTestObject.slowObjectValue;
-		}]];
+    __unsafe_unretained RACTestObject *unsafeTestObject = testObject;
+    [testObject.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+      deallocValue = unsafeTestObject.slowObjectValue;
+    }]];
 
-		[subject setKeyPath:@keypath(testObject.slowObjectValue) onObject:testObject];
-		expect(testObject.slowObjectValue).to(beNil());
+    [subject setKeyPath:@keypath(testObject.slowObjectValue) onObject:testObject];
+    expect(testObject.slowObjectValue).to(beNil());
 
-		// Attempt to deallocate concurrently.
-		[[RACScheduler scheduler] afterDelay:0.01 schedule:^{
-			testObject = nil;
-		}];
+    // Attempt to deallocate concurrently.
+    [[RACScheduler scheduler] afterDelay:0.01 schedule:^{
+      testObject = nil;
+    }];
 
-		expect(deallocValue).to(beNil());
-		[subject sendNext:@1];
-		expect(deallocValue).to(equal(@1));
-	});
+    expect(deallocValue).to(beNil());
+    [subject sendNext:@1];
+    expect(deallocValue).to(equal(@1));
+  });
 });
 
 qck_describe(@"memory management", ^{
-	qck_it(@"should dealloc signals if the signal does nothing", ^{
-		__block BOOL deallocd = NO;
-		@autoreleasepool {
-			RACSignal *signal __attribute__((objc_precise_lifetime)) = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-				return nil;
-			}];
+  qck_it(@"should dealloc signals if the signal does nothing", ^{
+    __block BOOL deallocd = NO;
+    @autoreleasepool {
+      RACSignal *signal __attribute__((objc_precise_lifetime)) = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+        return nil;
+      }];
 
-			[signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-				deallocd = YES;
-			}]];
-		}
+      [signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+        deallocd = YES;
+      }]];
+    }
 
-		expect(@(deallocd)).toEventually(beTruthy());
-	});
+    expect(@(deallocd)).toEventually(beTruthy());
+  });
 
-	qck_it(@"should dealloc signals if the signal immediately completes", ^{
-		__block BOOL deallocd = NO;
-		@autoreleasepool {
-			__block BOOL done = NO;
+  qck_it(@"should dealloc signals if the signal immediately completes", ^{
+    __block BOOL deallocd = NO;
+    @autoreleasepool {
+      __block BOOL done = NO;
 
-			RACSignal *signal __attribute__((objc_precise_lifetime)) = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-				[subscriber sendCompleted];
-				return nil;
-			}];
+      RACSignal *signal __attribute__((objc_precise_lifetime)) = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+        [subscriber sendCompleted];
+        return nil;
+      }];
 
-			[signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-				deallocd = YES;
-			}]];
+      [signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+        deallocd = YES;
+      }]];
 
-			[signal subscribeCompleted:^{
-				done = YES;
-			}];
+      [signal subscribeCompleted:^{
+        done = YES;
+      }];
 
-			expect(@(done)).toEventually(beTruthy());
-		}
+      expect(@(done)).toEventually(beTruthy());
+    }
 
-		expect(@(deallocd)).toEventually(beTruthy());
-	});
+    expect(@(deallocd)).toEventually(beTruthy());
+  });
 
-	qck_it(@"should dealloc a replay subject if it completes immediately", ^{
-		__block BOOL completed = NO;
-		__block BOOL deallocd = NO;
-		@autoreleasepool {
-			RACReplaySubject *subject __attribute__((objc_precise_lifetime)) = [RACReplaySubject subject];
-			[subject sendCompleted];
+  qck_it(@"should dealloc a replay subject if it completes immediately", ^{
+    __block BOOL completed = NO;
+    __block BOOL deallocd = NO;
+    @autoreleasepool {
+      RACReplaySubject *subject __attribute__((objc_precise_lifetime)) = [RACReplaySubject subject];
+      [subject sendCompleted];
 
-			[subject.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-				deallocd = YES;
-			}]];
+      [subject.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+        deallocd = YES;
+      }]];
 
-			[subject subscribeCompleted:^{
-				completed = YES;
-			}];
-		}
+      [subject subscribeCompleted:^{
+        completed = YES;
+      }];
+    }
 
-		expect(@(completed)).toEventually(beTruthy());
-		expect(@(deallocd)).toEventually(beTruthy());
-	});
+    expect(@(completed)).toEventually(beTruthy());
+    expect(@(deallocd)).toEventually(beTruthy());
+  });
 
-	qck_it(@"should dealloc if the signal was created on a background queue", ^{
-		__block BOOL completed = NO;
-		__block BOOL deallocd = NO;
-		@autoreleasepool {
-			[[RACScheduler scheduler] schedule:^{
-				RACSignal *signal __attribute__((objc_precise_lifetime)) = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-					[subscriber sendCompleted];
-					return nil;
-				}];
+  qck_it(@"should dealloc if the signal was created on a background queue", ^{
+    __block BOOL completed = NO;
+    __block BOOL deallocd = NO;
+    @autoreleasepool {
+      [[RACScheduler scheduler] schedule:^{
+        RACSignal *signal __attribute__((objc_precise_lifetime)) = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+          [subscriber sendCompleted];
+          return nil;
+        }];
 
-				[signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-					deallocd = YES;
-				}]];
+        [signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+          deallocd = YES;
+        }]];
 
-				[signal subscribeCompleted:^{
-					completed = YES;
-				}];
-			}];
-		}
+        [signal subscribeCompleted:^{
+          completed = YES;
+        }];
+      }];
+    }
 
-		expect(@(completed)).toEventually(beTruthy());
-		expect(@(deallocd)).toEventually(beTruthy());
-	});
+    expect(@(completed)).toEventually(beTruthy());
+    expect(@(deallocd)).toEventually(beTruthy());
+  });
 
-	qck_it(@"should dealloc if the signal was created on a background queue, never gets any subscribers, and the background queue gets delayed", ^{
-		__block BOOL deallocd = NO;
-		dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+  qck_it(@"should dealloc if the signal was created on a background queue, never gets any subscribers, and the background queue gets delayed", ^{
+    __block BOOL deallocd = NO;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-		@autoreleasepool {
-			[[RACScheduler scheduler] schedule:^{
-				RACSignal *signal __attribute__((objc_precise_lifetime)) = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-					return nil;
-				}];
+    @autoreleasepool {
+      [[RACScheduler scheduler] schedule:^{
+        RACSignal *signal __attribute__((objc_precise_lifetime)) = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+          return nil;
+        }];
 
-				[signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-					deallocd = YES;
-					dispatch_semaphore_signal(semaphore);
-				}]];
+        [signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+          deallocd = YES;
+          dispatch_semaphore_signal(semaphore);
+        }]];
 
-				[NSThread sleepForTimeInterval:1];
+        [NSThread sleepForTimeInterval:1];
 
-				expect(@(deallocd)).to(beFalsy());
-			}];
-		}
+        expect(@(deallocd)).to(beFalsy());
+      }];
+    }
 
-		dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-		expect(@(deallocd)).to(beTruthy());
-	});
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    expect(@(deallocd)).to(beTruthy());
+  });
 
-	qck_it(@"should retain intermediate signals when subscribing", ^{
-		RACSubject *subject = [RACSubject subject];
-		expect(subject).notTo(beNil());
+  qck_it(@"should retain intermediate signals when subscribing", ^{
+    RACSubject *subject = [RACSubject subject];
+    expect(subject).notTo(beNil());
 
-		__block BOOL gotNext = NO;
-		__block BOOL completed = NO;
+    __block BOOL gotNext = NO;
+    __block BOOL completed = NO;
 
-		RACDisposable *disposable;
+    RACDisposable *disposable;
 
-		@autoreleasepool {
-			RACSignal *intermediateSignal = [subject doNext:^(id _) {
-				gotNext = YES;
-			}];
+    @autoreleasepool {
+      RACSignal *intermediateSignal = [subject doNext:^(id _) {
+        gotNext = YES;
+      }];
 
-			expect(intermediateSignal).notTo(beNil());
+      expect(intermediateSignal).notTo(beNil());
 
-			disposable = [intermediateSignal subscribeCompleted:^{
-				completed = YES;
-			}];
-		}
+      disposable = [intermediateSignal subscribeCompleted:^{
+        completed = YES;
+      }];
+    }
 
-		[subject sendNext:@5];
-		expect(@(gotNext)).to(beTruthy());
+    [subject sendNext:@5];
+    expect(@(gotNext)).to(beTruthy());
 
-		[subject sendCompleted];
-		expect(@(completed)).to(beTruthy());
+    [subject sendCompleted];
+    expect(@(completed)).to(beTruthy());
 
-		[disposable dispose];
-	});
+    [disposable dispose];
+  });
 });
 
 qck_describe(@"-merge:", ^{
-	__block RACSubject *sub1;
-	__block RACSubject *sub2;
-	__block RACSignal *merged;
-	qck_beforeEach(^{
-		sub1 = [RACSubject subject];
-		sub2 = [RACSubject subject];
-		merged = [sub1 merge:sub2];
-	});
+  __block RACSubject *sub1;
+  __block RACSubject *sub2;
+  __block RACSignal *merged;
+  qck_beforeEach(^{
+    sub1 = [RACSubject subject];
+    sub2 = [RACSubject subject];
+    merged = [sub1 merge:sub2];
+  });
 
-	qck_it(@"should send all values from both signals", ^{
-		NSMutableArray *values = [NSMutableArray array];
-		[merged subscribeNext:^(id x) {
-			[values addObject:x];
-		}];
+  qck_it(@"should send all values from both signals", ^{
+    NSMutableArray *values = [NSMutableArray array];
+    [merged subscribeNext:^(id x) {
+      [values addObject:x];
+    }];
 
-		[sub1 sendNext:@1];
-		[sub2 sendNext:@2];
-		[sub2 sendNext:@3];
-		[sub1 sendNext:@4];
+    [sub1 sendNext:@1];
+    [sub2 sendNext:@2];
+    [sub2 sendNext:@3];
+    [sub1 sendNext:@4];
 
-		NSArray *expected = @[ @1, @2, @3, @4 ];
-		expect(values).to(equal(expected));
-	});
+    NSArray *expected = @[ @1, @2, @3, @4 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"should send an error if one occurs", ^{
-		__block NSError *errorReceived;
-		[merged subscribeError:^(NSError *error) {
-			errorReceived = error;
-		}];
+  qck_it(@"should send an error if one occurs", ^{
+    __block NSError *errorReceived;
+    [merged subscribeError:^(NSError *error) {
+      errorReceived = error;
+    }];
 
-		[sub1 sendError:RACSignalTestError];
-		expect(errorReceived).to(equal(RACSignalTestError));
-	});
+    [sub1 sendError:RACSignalTestError];
+    expect(errorReceived).to(equal(RACSignalTestError));
+  });
 
-	qck_it(@"should complete only after both signals complete", ^{
-		NSMutableArray *values = [NSMutableArray array];
-		__block BOOL completed = NO;
-		[merged subscribeNext:^(id x) {
-			[values addObject:x];
-		} completed:^{
-			completed = YES;
-		}];
+  qck_it(@"should complete only after both signals complete", ^{
+    NSMutableArray *values = [NSMutableArray array];
+    __block BOOL completed = NO;
+    [merged subscribeNext:^(id x) {
+      [values addObject:x];
+    } completed:^{
+      completed = YES;
+    }];
 
-		[sub1 sendNext:@1];
-		[sub2 sendNext:@2];
-		[sub2 sendNext:@3];
-		[sub2 sendCompleted];
-		expect(@(completed)).to(beFalsy());
+    [sub1 sendNext:@1];
+    [sub2 sendNext:@2];
+    [sub2 sendNext:@3];
+    [sub2 sendCompleted];
+    expect(@(completed)).to(beFalsy());
 
-		[sub1 sendNext:@4];
-		[sub1 sendCompleted];
-		expect(@(completed)).to(beTruthy());
+    [sub1 sendNext:@4];
+    [sub1 sendCompleted];
+    expect(@(completed)).to(beTruthy());
 
-		NSArray *expected = @[ @1, @2, @3, @4 ];
-		expect(values).to(equal(expected));
-	});
+    NSArray *expected = @[ @1, @2, @3, @4 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"should complete only after both signals complete for any number of subscribers", ^{
-		__block BOOL completed1 = NO;
-		__block BOOL completed2 = NO;
-		[merged subscribeCompleted:^{
-			completed1 = YES;
-		}];
+  qck_it(@"should complete only after both signals complete for any number of subscribers", ^{
+    __block BOOL completed1 = NO;
+    __block BOOL completed2 = NO;
+    [merged subscribeCompleted:^{
+      completed1 = YES;
+    }];
 
-		[merged subscribeCompleted:^{
-			completed2 = YES;
-		}];
+    [merged subscribeCompleted:^{
+      completed2 = YES;
+    }];
 
-		expect(@(completed1)).to(beFalsy());
-		expect(@(completed2)).to(beFalsy());
+    expect(@(completed1)).to(beFalsy());
+    expect(@(completed2)).to(beFalsy());
 
-		[sub1 sendCompleted];
-		[sub2 sendCompleted];
-		expect(@(completed1)).to(beTruthy());
-		expect(@(completed2)).to(beTruthy());
-	});
+    [sub1 sendCompleted];
+    [sub2 sendCompleted];
+    expect(@(completed1)).to(beTruthy());
+    expect(@(completed2)).to(beTruthy());
+  });
 });
 
 qck_describe(@"+merge:", ^{
-	__block RACSubject *sub1;
-	__block RACSubject *sub2;
-	__block RACSignal *merged;
-	qck_beforeEach(^{
-		sub1 = [RACSubject subject];
-		sub2 = [RACSubject subject];
-		merged = [RACSignal merge:@[ sub1, sub2 ].objectEnumerator];
-	});
+  __block RACSubject *sub1;
+  __block RACSubject *sub2;
+  __block RACSignal *merged;
+  qck_beforeEach(^{
+    sub1 = [RACSubject subject];
+    sub2 = [RACSubject subject];
+    merged = [RACSignal merge:@[ sub1, sub2 ].objectEnumerator];
+  });
 
-	qck_it(@"should send all values from both signals", ^{
-		NSMutableArray *values = [NSMutableArray array];
-		[merged subscribeNext:^(id x) {
-			[values addObject:x];
-		}];
+  qck_it(@"should send all values from both signals", ^{
+    NSMutableArray *values = [NSMutableArray array];
+    [merged subscribeNext:^(id x) {
+      [values addObject:x];
+    }];
 
-		[sub1 sendNext:@1];
-		[sub2 sendNext:@2];
-		[sub2 sendNext:@3];
-		[sub1 sendNext:@4];
+    [sub1 sendNext:@1];
+    [sub2 sendNext:@2];
+    [sub2 sendNext:@3];
+    [sub1 sendNext:@4];
 
-		NSArray *expected = @[ @1, @2, @3, @4 ];
-		expect(values).to(equal(expected));
-	});
+    NSArray *expected = @[ @1, @2, @3, @4 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"should send an error if one occurs", ^{
-		__block NSError *errorReceived;
-		[merged subscribeError:^(NSError *error) {
-			errorReceived = error;
-		}];
+  qck_it(@"should send an error if one occurs", ^{
+    __block NSError *errorReceived;
+    [merged subscribeError:^(NSError *error) {
+      errorReceived = error;
+    }];
 
-		[sub1 sendError:RACSignalTestError];
-		expect(errorReceived).to(equal(RACSignalTestError));
-	});
+    [sub1 sendError:RACSignalTestError];
+    expect(errorReceived).to(equal(RACSignalTestError));
+  });
 
-	qck_it(@"should complete only after both signals complete", ^{
-		NSMutableArray *values = [NSMutableArray array];
-		__block BOOL completed = NO;
-		[merged subscribeNext:^(id x) {
-			[values addObject:x];
-		} completed:^{
-			completed = YES;
-		}];
+  qck_it(@"should complete only after both signals complete", ^{
+    NSMutableArray *values = [NSMutableArray array];
+    __block BOOL completed = NO;
+    [merged subscribeNext:^(id x) {
+      [values addObject:x];
+    } completed:^{
+      completed = YES;
+    }];
 
-		[sub1 sendNext:@1];
-		[sub2 sendNext:@2];
-		[sub2 sendNext:@3];
-		[sub2 sendCompleted];
-		expect(@(completed)).to(beFalsy());
+    [sub1 sendNext:@1];
+    [sub2 sendNext:@2];
+    [sub2 sendNext:@3];
+    [sub2 sendCompleted];
+    expect(@(completed)).to(beFalsy());
 
-		[sub1 sendNext:@4];
-		[sub1 sendCompleted];
-		expect(@(completed)).to(beTruthy());
+    [sub1 sendNext:@4];
+    [sub1 sendCompleted];
+    expect(@(completed)).to(beTruthy());
 
-		NSArray *expected = @[ @1, @2, @3, @4 ];
-		expect(values).to(equal(expected));
-	});
+    NSArray *expected = @[ @1, @2, @3, @4 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"should complete immediately when not given any signals", ^{
-		RACSignal *signal = [RACSignal merge:@[].objectEnumerator];
+  qck_it(@"should complete immediately when not given any signals", ^{
+    RACSignal *signal = [RACSignal merge:@[].objectEnumerator];
 
-		__block BOOL completed = NO;
-		[signal subscribeCompleted:^{
-			completed = YES;
-		}];
+    __block BOOL completed = NO;
+    [signal subscribeCompleted:^{
+      completed = YES;
+    }];
 
-		expect(@(completed)).to(beTruthy());
-	});
+    expect(@(completed)).to(beTruthy());
+  });
 
-	qck_it(@"should complete only after both signals complete for any number of subscribers", ^{
-		__block BOOL completed1 = NO;
-		__block BOOL completed2 = NO;
-		[merged subscribeCompleted:^{
-			completed1 = YES;
-		}];
+  qck_it(@"should complete only after both signals complete for any number of subscribers", ^{
+    __block BOOL completed1 = NO;
+    __block BOOL completed2 = NO;
+    [merged subscribeCompleted:^{
+      completed1 = YES;
+    }];
 
-		[merged subscribeCompleted:^{
-			completed2 = YES;
-		}];
+    [merged subscribeCompleted:^{
+      completed2 = YES;
+    }];
 
-		expect(@(completed1)).to(beFalsy());
-		expect(@(completed2)).to(beFalsy());
+    expect(@(completed1)).to(beFalsy());
+    expect(@(completed2)).to(beFalsy());
 
-		[sub1 sendCompleted];
-		[sub2 sendCompleted];
-		expect(@(completed1)).to(beTruthy());
-		expect(@(completed2)).to(beTruthy());
-	});
+    [sub1 sendCompleted];
+    [sub2 sendCompleted];
+    expect(@(completed1)).to(beTruthy());
+    expect(@(completed2)).to(beTruthy());
+  });
 });
 
 qck_describe(@"-flatten:", ^{
-	__block BOOL subscribedTo1 = NO;
-	__block BOOL subscribedTo2 = NO;
-	__block BOOL subscribedTo3 = NO;
-	__block RACSignal *sub1;
-	__block RACSignal *sub2;
-	__block RACSignal *sub3;
-	__block RACSubject *subject1;
-	__block RACSubject *subject2;
-	__block RACSubject *subject3;
-	__block RACSubject *signalsSubject;
-	__block NSMutableArray *values;
+  __block BOOL subscribedTo1 = NO;
+  __block BOOL subscribedTo2 = NO;
+  __block BOOL subscribedTo3 = NO;
+  __block RACSignal *sub1;
+  __block RACSignal *sub2;
+  __block RACSignal *sub3;
+  __block RACSubject *subject1;
+  __block RACSubject *subject2;
+  __block RACSubject *subject3;
+  __block RACSubject *signalsSubject;
+  __block NSMutableArray *values;
 
-	qck_beforeEach(^{
-		subscribedTo1 = NO;
-		subject1 = [RACSubject subject];
-		sub1 = [RACSignal defer:^{
-			subscribedTo1 = YES;
-			return subject1;
-		}];
+  qck_beforeEach(^{
+    subscribedTo1 = NO;
+    subject1 = [RACSubject subject];
+    sub1 = [RACSignal defer:^{
+      subscribedTo1 = YES;
+      return subject1;
+    }];
 
-		subscribedTo2 = NO;
-		subject2 = [RACSubject subject];
-		sub2 = [RACSignal defer:^{
-			subscribedTo2 = YES;
-			return subject2;
-		}];
+    subscribedTo2 = NO;
+    subject2 = [RACSubject subject];
+    sub2 = [RACSignal defer:^{
+      subscribedTo2 = YES;
+      return subject2;
+    }];
 
-		subscribedTo3 = NO;
-		subject3 = [RACSubject subject];
-		sub3 = [RACSignal defer:^{
-			subscribedTo3 = YES;
-			return subject3;
-		}];
+    subscribedTo3 = NO;
+    subject3 = [RACSubject subject];
+    sub3 = [RACSignal defer:^{
+      subscribedTo3 = YES;
+      return subject3;
+    }];
 
-		signalsSubject = [RACSubject subject];
+    signalsSubject = [RACSubject subject];
 
-		values = [NSMutableArray array];
-	});
+    values = [NSMutableArray array];
+  });
 
-	qck_describe(@"when its max is 0", ^{
-		qck_it(@"should merge all the signals concurrently", ^{
-			[[signalsSubject flatten:0] subscribeNext:^(id x) {
-				[values addObject:x];
-			}];
+  qck_describe(@"when its max is 0", ^{
+    qck_it(@"should merge all the signals concurrently", ^{
+      [[signalsSubject flatten:0] subscribeNext:^(id x) {
+        [values addObject:x];
+      }];
 
-			expect(@(subscribedTo1)).to(beFalsy());
-			expect(@(subscribedTo2)).to(beFalsy());
-			expect(@(subscribedTo3)).to(beFalsy());
+      expect(@(subscribedTo1)).to(beFalsy());
+      expect(@(subscribedTo2)).to(beFalsy());
+      expect(@(subscribedTo3)).to(beFalsy());
 
-			[signalsSubject sendNext:sub1];
-			[signalsSubject sendNext:sub2];
+      [signalsSubject sendNext:sub1];
+      [signalsSubject sendNext:sub2];
 
-			expect(@(subscribedTo1)).to(beTruthy());
-			expect(@(subscribedTo2)).to(beTruthy());
-			expect(@(subscribedTo3)).to(beFalsy());
+      expect(@(subscribedTo1)).to(beTruthy());
+      expect(@(subscribedTo2)).to(beTruthy());
+      expect(@(subscribedTo3)).to(beFalsy());
 
-			[subject1 sendNext:@1];
+      [subject1 sendNext:@1];
 
-			[signalsSubject sendNext:sub3];
+      [signalsSubject sendNext:sub3];
 
-			expect(@(subscribedTo1)).to(beTruthy());
-			expect(@(subscribedTo2)).to(beTruthy());
-			expect(@(subscribedTo3)).to(beTruthy());
+      expect(@(subscribedTo1)).to(beTruthy());
+      expect(@(subscribedTo2)).to(beTruthy());
+      expect(@(subscribedTo3)).to(beTruthy());
 
-			[subject1 sendCompleted];
+      [subject1 sendCompleted];
 
-			[subject2 sendNext:@2];
-			[subject2 sendCompleted];
+      [subject2 sendNext:@2];
+      [subject2 sendCompleted];
 
-			[subject3 sendNext:@3];
-			[subject3 sendCompleted];
+      [subject3 sendNext:@3];
+      [subject3 sendCompleted];
 
-			NSArray *expected = @[ @1, @2, @3 ];
-			expect(values).to(equal(expected));
-		});
+      NSArray *expected = @[ @1, @2, @3 ];
+      expect(values).to(equal(expected));
+    });
 
-		qck_itBehavesLike(RACSignalMergeConcurrentCompletionExampleGroup, ^{
-			return @{ RACSignalMaxConcurrent: @0 };
-		});
-	});
+    qck_itBehavesLike(RACSignalMergeConcurrentCompletionExampleGroup, ^{
+      return @{ RACSignalMaxConcurrent: @0 };
+    });
+  });
 
-	qck_describe(@"when its max is > 0", ^{
-		qck_it(@"should merge only the given number at a time", ^{
-			[[signalsSubject flatten:1] subscribeNext:^(id x) {
-				[values addObject:x];
-			}];
+  qck_describe(@"when its max is > 0", ^{
+    qck_it(@"should merge only the given number at a time", ^{
+      [[signalsSubject flatten:1] subscribeNext:^(id x) {
+        [values addObject:x];
+      }];
 
-			expect(@(subscribedTo1)).to(beFalsy());
-			expect(@(subscribedTo2)).to(beFalsy());
-			expect(@(subscribedTo3)).to(beFalsy());
+      expect(@(subscribedTo1)).to(beFalsy());
+      expect(@(subscribedTo2)).to(beFalsy());
+      expect(@(subscribedTo3)).to(beFalsy());
 
-			[signalsSubject sendNext:sub1];
-			[signalsSubject sendNext:sub2];
+      [signalsSubject sendNext:sub1];
+      [signalsSubject sendNext:sub2];
 
-			expect(@(subscribedTo1)).to(beTruthy());
-			expect(@(subscribedTo2)).to(beFalsy());
-			expect(@(subscribedTo3)).to(beFalsy());
+      expect(@(subscribedTo1)).to(beTruthy());
+      expect(@(subscribedTo2)).to(beFalsy());
+      expect(@(subscribedTo3)).to(beFalsy());
 
-			[subject1 sendNext:@1];
+      [subject1 sendNext:@1];
 
-			[signalsSubject sendNext:sub3];
+      [signalsSubject sendNext:sub3];
 
-			expect(@(subscribedTo1)).to(beTruthy());
-			expect(@(subscribedTo2)).to(beFalsy());
-			expect(@(subscribedTo3)).to(beFalsy());
+      expect(@(subscribedTo1)).to(beTruthy());
+      expect(@(subscribedTo2)).to(beFalsy());
+      expect(@(subscribedTo3)).to(beFalsy());
 
-			[signalsSubject sendCompleted];
+      [signalsSubject sendCompleted];
 
-			expect(@(subscribedTo1)).to(beTruthy());
-			expect(@(subscribedTo2)).to(beFalsy());
-			expect(@(subscribedTo3)).to(beFalsy());
+      expect(@(subscribedTo1)).to(beTruthy());
+      expect(@(subscribedTo2)).to(beFalsy());
+      expect(@(subscribedTo3)).to(beFalsy());
 
-			[subject1 sendCompleted];
+      [subject1 sendCompleted];
 
-			expect(@(subscribedTo2)).to(beTruthy());
-			expect(@(subscribedTo3)).to(beFalsy());
+      expect(@(subscribedTo2)).to(beTruthy());
+      expect(@(subscribedTo3)).to(beFalsy());
 
-			[subject2 sendNext:@2];
-			[subject2 sendCompleted];
+      [subject2 sendNext:@2];
+      [subject2 sendCompleted];
 
-			expect(@(subscribedTo3)).to(beTruthy());
+      expect(@(subscribedTo3)).to(beTruthy());
 
-			[subject3 sendNext:@3];
-			[subject3 sendCompleted];
+      [subject3 sendNext:@3];
+      [subject3 sendCompleted];
 
-			NSArray *expected = @[ @1, @2, @3 ];
-			expect(values).to(equal(expected));
-		});
+      NSArray *expected = @[ @1, @2, @3 ];
+      expect(values).to(equal(expected));
+    });
 
-		qck_itBehavesLike(RACSignalMergeConcurrentCompletionExampleGroup, ^{
-			return @{ RACSignalMaxConcurrent: @1 };
-		});
-	});
+    qck_itBehavesLike(RACSignalMergeConcurrentCompletionExampleGroup, ^{
+      return @{ RACSignalMaxConcurrent: @1 };
+    });
+  });
 
-	qck_it(@"shouldn't create a retain cycle", ^{
-		__block BOOL subjectDeallocd = NO;
-		__block BOOL signalDeallocd = NO;
-		@autoreleasepool {
-			RACSubject *subject __attribute__((objc_precise_lifetime)) = [RACSubject subject];
-			[subject.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-				subjectDeallocd = YES;
-			}]];
+  qck_it(@"shouldn't create a retain cycle", ^{
+    __block BOOL subjectDeallocd = NO;
+    __block BOOL signalDeallocd = NO;
+    @autoreleasepool {
+      RACSubject *subject __attribute__((objc_precise_lifetime)) = [RACSubject subject];
+      [subject.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+        subjectDeallocd = YES;
+      }]];
 
-			RACSignal *signal __attribute__((objc_precise_lifetime)) = [subject flatten];
-			[signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
-				signalDeallocd = YES;
-			}]];
+      RACSignal *signal __attribute__((objc_precise_lifetime)) = [subject flatten];
+      [signal.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+        signalDeallocd = YES;
+      }]];
 
-			[signal subscribeCompleted:^{}];
+      [signal subscribeCompleted:^{}];
 
-			[subject sendCompleted];
-		}
+      [subject sendCompleted];
+    }
 
-		expect(@(subjectDeallocd)).toEventually(beTruthy());
-		expect(@(signalDeallocd)).toEventually(beTruthy());
-	});
+    expect(@(subjectDeallocd)).toEventually(beTruthy());
+    expect(@(signalDeallocd)).toEventually(beTruthy());
+  });
 
-	qck_it(@"should not crash when disposing while subscribing", ^{
-		RACDisposable *disposable = [[signalsSubject flatten:0] subscribeCompleted:^{
-		}];
+  qck_it(@"should not crash when disposing while subscribing", ^{
+    RACDisposable *disposable = [[signalsSubject flatten:0] subscribeCompleted:^{
+    }];
 
-		[signalsSubject sendNext:[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[disposable dispose];
-			[subscriber sendCompleted];
-			return nil;
-		}]];
+    [signalsSubject sendNext:[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [disposable dispose];
+      [subscriber sendCompleted];
+      return nil;
+    }]];
 
-		[signalsSubject sendCompleted];
-	});
+    [signalsSubject sendCompleted];
+  });
 
-	qck_it(@"should dispose after last synchronous signal subscription and should not crash", ^{
+  qck_it(@"should dispose after last synchronous signal subscription and should not crash", ^{
 
-		RACSignal *flattened = [signalsSubject flatten:1];
-		RACDisposable *flattenDisposable = [flattened subscribeCompleted:^{}];
+    RACSignal *flattened = [signalsSubject flatten:1];
+    RACDisposable *flattenDisposable = [flattened subscribeCompleted:^{}];
 
-		RACSignal *syncSignal = [RACSignal createSignal:^ RACDisposable *(id<RACSubscriber> subscriber) {
-			expect(@(flattenDisposable.disposed)).to(beFalsy());
-			[subscriber sendCompleted];
-			expect(@(flattenDisposable.disposed)).to(beTruthy());
-			return nil;
-		}];
+    RACSignal *syncSignal = [RACSignal createSignal:^ RACDisposable *(id<RACSubscriber> subscriber) {
+      expect(@(flattenDisposable.disposed)).to(beFalsy());
+      [subscriber sendCompleted];
+      expect(@(flattenDisposable.disposed)).to(beTruthy());
+      return nil;
+    }];
 
-		RACSignal *asyncSignal = [sub1 delay:0];
+    RACSignal *asyncSignal = [sub1 delay:0];
 
-		[signalsSubject sendNext:asyncSignal];
-		[signalsSubject sendNext:syncSignal];
+    [signalsSubject sendNext:asyncSignal];
+    [signalsSubject sendNext:syncSignal];
 
-		[signalsSubject sendCompleted];
+    [signalsSubject sendCompleted];
 
-		[subject1 sendCompleted];
+    [subject1 sendCompleted];
 
-		expect(@(flattenDisposable.disposed)).toEventually(beTruthy());
-	});
+    expect(@(flattenDisposable.disposed)).toEventually(beTruthy());
+  });
 
-	qck_it(@"should not crash when disposed because of takeUntil:", ^{
-		for (int i = 0; i < 100; i++) {
-			RACSubject *flattenedReceiver = [RACSubject subject];
-			RACSignal *done = [flattenedReceiver map:^(NSNumber *n) {
-				return @(n.integerValue == 1);
-			}];
+  qck_it(@"should not crash when disposed because of takeUntil:", ^{
+    for (int i = 0; i < 100; i++) {
+      RACSubject *flattenedReceiver = [RACSubject subject];
+      RACSignal *done = [flattenedReceiver map:^(NSNumber *n) {
+        return @(n.integerValue == 1);
+      }];
 
-			RACSignal *flattened = [signalsSubject flatten:1];
+      RACSignal *flattened = [signalsSubject flatten:1];
 
-			RACDisposable *flattenDisposable = [[flattened takeUntil:[done ignore:@NO]] subscribe:flattenedReceiver];
+      RACDisposable *flattenDisposable = [[flattened takeUntil:[done ignore:@NO]] subscribe:flattenedReceiver];
 
-			RACSignal *syncSignal = [RACSignal createSignal:^ RACDisposable *(id<RACSubscriber> subscriber) {
-				expect(@(flattenDisposable.disposed)).to(beFalsy());
-				[subscriber sendNext:@1];
-				expect(@(flattenDisposable.disposed)).to(beTruthy());
-				[subscriber sendCompleted];
-				return nil;
-			}];
+      RACSignal *syncSignal = [RACSignal createSignal:^ RACDisposable *(id<RACSubscriber> subscriber) {
+        expect(@(flattenDisposable.disposed)).to(beFalsy());
+        [subscriber sendNext:@1];
+        expect(@(flattenDisposable.disposed)).to(beTruthy());
+        [subscriber sendCompleted];
+        return nil;
+      }];
 
-			RACSignal *asyncSignal = [sub1 delay:0];
-			[subject1 sendNext:@0];
+      RACSignal *asyncSignal = [sub1 delay:0];
+      [subject1 sendNext:@0];
 
-			[signalsSubject sendNext:asyncSignal];
-			[signalsSubject sendNext:syncSignal];
-			[signalsSubject sendCompleted];
+      [signalsSubject sendNext:asyncSignal];
+      [signalsSubject sendNext:syncSignal];
+      [signalsSubject sendCompleted];
 
-			[subject1 sendCompleted];
+      [subject1 sendCompleted];
 
-			expect(@(flattenDisposable.disposed)).toEventually(beTruthy());
-		}
-	});
+      expect(@(flattenDisposable.disposed)).toEventually(beTruthy());
+    }
+  });
 });
 
 qck_describe(@"-switchToLatest", ^{
-	__block RACSubject *subject;
+  __block RACSubject *subject;
 
-	__block NSMutableArray *values;
-	__block NSError *lastError = nil;
-	__block BOOL completed = NO;
+  __block NSMutableArray *values;
+  __block NSError *lastError = nil;
+  __block BOOL completed = NO;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
 
-		values = [NSMutableArray array];
-		lastError = nil;
-		completed = NO;
+    values = [NSMutableArray array];
+    lastError = nil;
+    completed = NO;
 
-		[[subject switchToLatest] subscribeNext:^(id x) {
-			expect(lastError).to(beNil());
-			expect(@(completed)).to(beFalsy());
+    [[subject switchToLatest] subscribeNext:^(id x) {
+      expect(lastError).to(beNil());
+      expect(@(completed)).to(beFalsy());
 
-			[values addObject:x];
-		} error:^(NSError *error) {
-			expect(lastError).to(beNil());
-			expect(@(completed)).to(beFalsy());
+      [values addObject:x];
+    } error:^(NSError *error) {
+      expect(lastError).to(beNil());
+      expect(@(completed)).to(beFalsy());
 
-			lastError = error;
-		} completed:^{
-			expect(lastError).to(beNil());
-			expect(@(completed)).to(beFalsy());
+      lastError = error;
+    } completed:^{
+      expect(lastError).to(beNil());
+      expect(@(completed)).to(beFalsy());
 
-			completed = YES;
-		}];
-	});
+      completed = YES;
+    }];
+  });
 
-	qck_it(@"should send values from the most recent signal", ^{
-		[subject sendNext:[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@1];
-			[subscriber sendNext:@2];
-			return nil;
-		}]];
+  qck_it(@"should send values from the most recent signal", ^{
+    [subject sendNext:[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@1];
+      [subscriber sendNext:@2];
+      return nil;
+    }]];
 
-		[subject sendNext:[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@3];
-			[subscriber sendNext:@4];
-			return nil;
-		}]];
+    [subject sendNext:[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@3];
+      [subscriber sendNext:@4];
+      return nil;
+    }]];
 
-		NSArray *expected = @[ @1, @2, @3, @4 ];
-		expect(values).to(equal(expected));
-	});
+    NSArray *expected = @[ @1, @2, @3, @4 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"should send errors from the most recent signal", ^{
-		[subject sendNext:[RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
-			return nil;
-		}]];
+  qck_it(@"should send errors from the most recent signal", ^{
+    [subject sendNext:[RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
+      return nil;
+    }]];
 
-		expect(lastError).notTo(beNil());
-	});
+    expect(lastError).notTo(beNil());
+  });
 
-	qck_it(@"should not send completed if only the switching signal completes", ^{
-		[subject sendNext:RACSignal.never];
+  qck_it(@"should not send completed if only the switching signal completes", ^{
+    [subject sendNext:RACSignal.never];
 
-		expect(@(completed)).to(beFalsy());
+    expect(@(completed)).to(beFalsy());
 
-		[subject sendCompleted];
-		expect(@(completed)).to(beFalsy());
-	});
+    [subject sendCompleted];
+    expect(@(completed)).to(beFalsy());
+  });
 
-	qck_it(@"should send completed when the switching signal completes and the last sent signal does", ^{
-		[subject sendNext:RACSignal.empty];
+  qck_it(@"should send completed when the switching signal completes and the last sent signal does", ^{
+    [subject sendNext:RACSignal.empty];
 
-		expect(@(completed)).to(beFalsy());
+    expect(@(completed)).to(beFalsy());
 
-		[subject sendCompleted];
-		expect(@(completed)).to(beTruthy());
-	});
+    [subject sendCompleted];
+    expect(@(completed)).to(beTruthy());
+  });
 
-	qck_it(@"should accept nil signals", ^{
-		[subject sendNext:nil];
-		[subject sendNext:[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:@1];
-			[subscriber sendNext:@2];
-			return nil;
-		}]];
+  qck_it(@"should accept nil signals", ^{
+    [subject sendNext:nil];
+    [subject sendNext:[RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:@1];
+      [subscriber sendNext:@2];
+      return nil;
+    }]];
 
-		NSArray *expected = @[ @1, @2 ];
-		expect(values).to(equal(expected));
-	});
+    NSArray *expected = @[ @1, @2 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"should return a cold signal", ^{
-		__block NSUInteger subscriptions = 0;
-		RACSignal *signalOfSignals = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			subscriptions++;
-			[subscriber sendNext:[RACSignal empty]];
-			return nil;
-		}];
+  qck_it(@"should return a cold signal", ^{
+    __block NSUInteger subscriptions = 0;
+    RACSignal *signalOfSignals = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      subscriptions++;
+      [subscriber sendNext:[RACSignal empty]];
+      return nil;
+    }];
 
-		RACSignal *switched = [signalOfSignals switchToLatest];
+    RACSignal *switched = [signalOfSignals switchToLatest];
 
-		[[switched publish] connect];
-		expect(@(subscriptions)).to(equal(@1));
+    [[switched publish] connect];
+    expect(@(subscriptions)).to(equal(@1));
 
-		[[switched publish] connect];
-		expect(@(subscriptions)).to(equal(@2));
-	});
+    [[switched publish] connect];
+    expect(@(subscriptions)).to(equal(@2));
+  });
 });
 
 qck_describe(@"+switch:cases:default:", ^{
-	__block RACSubject *keySubject;
+  __block RACSubject *keySubject;
 
-	__block RACSubject *subjectZero;
-	__block RACSubject *subjectOne;
-	__block RACSubject *subjectTwo;
+  __block RACSubject *subjectZero;
+  __block RACSubject *subjectOne;
+  __block RACSubject *subjectTwo;
 
-	__block RACSubject *defaultSubject;
+  __block RACSubject *defaultSubject;
 
-	__block NSMutableArray *values;
-	__block NSError *lastError = nil;
-	__block BOOL completed = NO;
+  __block NSMutableArray *values;
+  __block NSError *lastError = nil;
+  __block BOOL completed = NO;
 
-	qck_beforeEach(^{
-		keySubject = [RACSubject subject];
+  qck_beforeEach(^{
+    keySubject = [RACSubject subject];
 
-		subjectZero = [RACSubject subject];
-		subjectOne = [RACSubject subject];
-		subjectTwo = [RACSubject subject];
+    subjectZero = [RACSubject subject];
+    subjectOne = [RACSubject subject];
+    subjectTwo = [RACSubject subject];
 
-		defaultSubject = [RACSubject subject];
+    defaultSubject = [RACSubject subject];
 
-		values = [NSMutableArray array];
-		lastError = nil;
-		completed = NO;
-	});
+    values = [NSMutableArray array];
+    lastError = nil;
+    completed = NO;
+  });
 
-	qck_describe(@"switching between values with a default", ^{
-		__block RACSignal *switchSignal;
+  qck_describe(@"switching between values with a default", ^{
+    __block RACSignal *switchSignal;
 
-		qck_beforeEach(^{
-			switchSignal = [RACSignal switch:keySubject cases:@{
-				@0: subjectZero,
-				@1: subjectOne,
-				@2: subjectTwo,
-			} default:[RACSignal never]];
+    qck_beforeEach(^{
+      switchSignal = [RACSignal switch:keySubject cases:@{
+        @0: subjectZero,
+        @1: subjectOne,
+        @2: subjectTwo,
+      } default:[RACSignal never]];
 
-			[switchSignal subscribeNext:^(id x) {
-				expect(lastError).to(beNil());
-				expect(@(completed)).to(beFalsy());
+      [switchSignal subscribeNext:^(id x) {
+        expect(lastError).to(beNil());
+        expect(@(completed)).to(beFalsy());
 
-				[values addObject:x];
-			} error:^(NSError *error) {
-				expect(lastError).to(beNil());
-				expect(@(completed)).to(beFalsy());
+        [values addObject:x];
+      } error:^(NSError *error) {
+        expect(lastError).to(beNil());
+        expect(@(completed)).to(beFalsy());
 
-				lastError = error;
-			} completed:^{
-				expect(lastError).to(beNil());
-				expect(@(completed)).to(beFalsy());
+        lastError = error;
+      } completed:^{
+        expect(lastError).to(beNil());
+        expect(@(completed)).to(beFalsy());
 
-				completed = YES;
-			}];
-		});
+        completed = YES;
+      }];
+    });
 
-		qck_it(@"should not send any values before a key is sent", ^{
-			[subjectZero sendNext:RACUnit.defaultUnit];
-			[subjectOne sendNext:RACUnit.defaultUnit];
-			[subjectTwo sendNext:RACUnit.defaultUnit];
+    qck_it(@"should not send any values before a key is sent", ^{
+      [subjectZero sendNext:RACUnit.defaultUnit];
+      [subjectOne sendNext:RACUnit.defaultUnit];
+      [subjectTwo sendNext:RACUnit.defaultUnit];
 
-			expect(values).to(equal(@[]));
-			expect(lastError).to(beNil());
-			expect(@(completed)).to(beFalsy());
-		});
+      expect(values).to(equal(@[]));
+      expect(lastError).to(beNil());
+      expect(@(completed)).to(beFalsy());
+    });
 
-		qck_it(@"should send events based on the latest key", ^{
-			[keySubject sendNext:@0];
+    qck_it(@"should send events based on the latest key", ^{
+      [keySubject sendNext:@0];
 
-			[subjectZero sendNext:@"zero"];
-			[subjectZero sendNext:@"zero"];
-			[subjectOne sendNext:@"one"];
-			[subjectTwo sendNext:@"two"];
+      [subjectZero sendNext:@"zero"];
+      [subjectZero sendNext:@"zero"];
+      [subjectOne sendNext:@"one"];
+      [subjectTwo sendNext:@"two"];
 
-			NSArray *expected = @[ @"zero", @"zero" ];
-			expect(values).to(equal(expected));
+      NSArray *expected = @[ @"zero", @"zero" ];
+      expect(values).to(equal(expected));
 
-			[keySubject sendNext:@1];
+      [keySubject sendNext:@1];
 
-			[subjectZero sendNext:@"zero"];
-			[subjectOne sendNext:@"one"];
-			[subjectTwo sendNext:@"two"];
+      [subjectZero sendNext:@"zero"];
+      [subjectOne sendNext:@"one"];
+      [subjectTwo sendNext:@"two"];
 
-			expected = @[ @"zero", @"zero", @"one" ];
-			expect(values).to(equal(expected));
+      expected = @[ @"zero", @"zero", @"one" ];
+      expect(values).to(equal(expected));
 
-			expect(lastError).to(beNil());
-			expect(@(completed)).to(beFalsy());
+      expect(lastError).to(beNil());
+      expect(@(completed)).to(beFalsy());
 
-			[keySubject sendNext:@2];
+      [keySubject sendNext:@2];
 
-			[subjectZero sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
-			[subjectOne sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
-			expect(lastError).to(beNil());
+      [subjectZero sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
+      [subjectOne sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
+      expect(lastError).to(beNil());
 
-			[subjectTwo sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
-			expect(lastError).notTo(beNil());
-		});
+      [subjectTwo sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
+      expect(lastError).notTo(beNil());
+    });
 
-		qck_it(@"should not send completed when only the key signal completes", ^{
-			[keySubject sendNext:@0];
-			[subjectZero sendNext:@"zero"];
-			[keySubject sendCompleted];
+    qck_it(@"should not send completed when only the key signal completes", ^{
+      [keySubject sendNext:@0];
+      [subjectZero sendNext:@"zero"];
+      [keySubject sendCompleted];
 
-			expect(values).to(equal(@[ @"zero" ]));
-			expect(@(completed)).to(beFalsy());
-		});
+      expect(values).to(equal(@[ @"zero" ]));
+      expect(@(completed)).to(beFalsy());
+    });
 
-		qck_it(@"should send completed when the key signal and the latest sent signal complete", ^{
-			[keySubject sendNext:@0];
-			[subjectZero sendNext:@"zero"];
-			[keySubject sendCompleted];
-			[subjectZero sendCompleted];
+    qck_it(@"should send completed when the key signal and the latest sent signal complete", ^{
+      [keySubject sendNext:@0];
+      [subjectZero sendNext:@"zero"];
+      [keySubject sendCompleted];
+      [subjectZero sendCompleted];
 
-			expect(values).to(equal(@[ @"zero" ]));
-			expect(@(completed)).to(beTruthy());
-		});
-	});
+      expect(values).to(equal(@[ @"zero" ]));
+      expect(@(completed)).to(beTruthy());
+    });
+  });
 
-	qck_it(@"should use the default signal if key that was sent does not have an associated signal", ^{
-		[[RACSignal
-			switch:keySubject
-			cases:@{
-				@0: subjectZero,
-				@1: subjectOne,
-			}
-			default:defaultSubject]
-			subscribeNext:^(id x) {
-				[values addObject:x];
-			}];
+  qck_it(@"should use the default signal if key that was sent does not have an associated signal", ^{
+    [[RACSignal
+      switch:keySubject
+      cases:@{
+        @0: subjectZero,
+        @1: subjectOne,
+      }
+      default:defaultSubject]
+      subscribeNext:^(id x) {
+        [values addObject:x];
+      }];
 
-		[keySubject sendNext:@"not a valid key"];
-		[defaultSubject sendNext:@"default"];
+    [keySubject sendNext:@"not a valid key"];
+    [defaultSubject sendNext:@"default"];
 
-		expect(values).to(equal(@[ @"default" ]));
+    expect(values).to(equal(@[ @"default" ]));
 
-		[keySubject sendNext:nil];
-		[defaultSubject sendNext:@"default"];
+    [keySubject sendNext:nil];
+    [defaultSubject sendNext:@"default"];
 
-		expect(values).to(equal((@[ @"default", @"default" ])));
-	});
+    expect(values).to(equal((@[ @"default", @"default" ])));
+  });
 
-	qck_it(@"should send an error if key that was sent does not have an associated signal and there's no default", ^{
-		[[RACSignal
-			switch:keySubject
-			cases:@{
-				@0: subjectZero,
-				@1: subjectOne,
-			}
-			default:nil]
-			subscribeNext:^(id x) {
-				[values addObject:x];
-			} error:^(NSError *error) {
-				lastError = error;
-			}];
+  qck_it(@"should send an error if key that was sent does not have an associated signal and there's no default", ^{
+    [[RACSignal
+      switch:keySubject
+      cases:@{
+        @0: subjectZero,
+        @1: subjectOne,
+      }
+      default:nil]
+      subscribeNext:^(id x) {
+        [values addObject:x];
+      } error:^(NSError *error) {
+        lastError = error;
+      }];
 
-		[keySubject sendNext:@0];
-		[subjectZero sendNext:@"zero"];
+    [keySubject sendNext:@0];
+    [subjectZero sendNext:@"zero"];
 
-		expect(values).to(equal(@[ @"zero" ]));
-		expect(lastError).to(beNil());
+    expect(values).to(equal(@[ @"zero" ]));
+    expect(lastError).to(beNil());
 
-		[keySubject sendNext:nil];
+    [keySubject sendNext:nil];
 
-		expect(values).to(equal(@[ @"zero" ]));
-		expect(lastError).notTo(beNil());
-		expect(lastError.domain).to(equal(RACSignalErrorDomain));
-		expect(@(lastError.code)).to(equal(@(RACSignalErrorNoMatchingCase)));
-	});
+    expect(values).to(equal(@[ @"zero" ]));
+    expect(lastError).notTo(beNil());
+    expect(lastError.domain).to(equal(RACSignalErrorDomain));
+    expect(@(lastError.code)).to(equal(@(RACSignalErrorNoMatchingCase)));
+  });
 
-	qck_it(@"should match RACTupleNil case when a nil value is sent", ^{
-		[[RACSignal
-			switch:keySubject
-			cases:@{
-				RACTupleNil.tupleNil: subjectZero,
-			}
-			default:defaultSubject]
-			subscribeNext:^(id x) {
-				[values addObject:x];
-			}];
+  qck_it(@"should match RACTupleNil case when a nil value is sent", ^{
+    [[RACSignal
+      switch:keySubject
+      cases:@{
+        RACTupleNil.tupleNil: subjectZero,
+      }
+      default:defaultSubject]
+      subscribeNext:^(id x) {
+        [values addObject:x];
+      }];
 
-		[keySubject sendNext:nil];
-		[subjectZero sendNext:@"zero"];
-		expect(values).to(equal(@[ @"zero" ]));
-	});
+    [keySubject sendNext:nil];
+    [subjectZero sendNext:@"zero"];
+    expect(values).to(equal(@[ @"zero" ]));
+  });
 });
 
 qck_describe(@"+if:then:else", ^{
-	__block RACSubject *boolSubject;
-	__block RACSubject *trueSubject;
-	__block RACSubject *falseSubject;
+  __block RACSubject *boolSubject;
+  __block RACSubject *trueSubject;
+  __block RACSubject *falseSubject;
 
-	__block NSMutableArray *values;
-	__block NSError *lastError = nil;
-	__block BOOL completed = NO;
+  __block NSMutableArray *values;
+  __block NSError *lastError = nil;
+  __block BOOL completed = NO;
 
-	qck_beforeEach(^{
-		boolSubject = [RACSubject subject];
-		trueSubject = [RACSubject subject];
-		falseSubject = [RACSubject subject];
+  qck_beforeEach(^{
+    boolSubject = [RACSubject subject];
+    trueSubject = [RACSubject subject];
+    falseSubject = [RACSubject subject];
 
-		values = [NSMutableArray array];
-		lastError = nil;
-		completed = NO;
+    values = [NSMutableArray array];
+    lastError = nil;
+    completed = NO;
 
-		[[RACSignal if:boolSubject then:trueSubject else:falseSubject] subscribeNext:^(id x) {
-			expect(lastError).to(beNil());
-			expect(@(completed)).to(beFalsy());
+    [[RACSignal if:boolSubject then:trueSubject else:falseSubject] subscribeNext:^(id x) {
+      expect(lastError).to(beNil());
+      expect(@(completed)).to(beFalsy());
 
-			[values addObject:x];
-		} error:^(NSError *error) {
-			expect(lastError).to(beNil());
-			expect(@(completed)).to(beFalsy());
+      [values addObject:x];
+    } error:^(NSError *error) {
+      expect(lastError).to(beNil());
+      expect(@(completed)).to(beFalsy());
 
-			lastError = error;
-		} completed:^{
-			expect(lastError).to(beNil());
-			expect(@(completed)).to(beFalsy());
+      lastError = error;
+    } completed:^{
+      expect(lastError).to(beNil());
+      expect(@(completed)).to(beFalsy());
 
-			completed = YES;
-		}];
-	});
+      completed = YES;
+    }];
+  });
 
-	qck_it(@"should not send any values before a boolean is sent", ^{
-		[trueSubject sendNext:RACUnit.defaultUnit];
-		[falseSubject sendNext:RACUnit.defaultUnit];
+  qck_it(@"should not send any values before a boolean is sent", ^{
+    [trueSubject sendNext:RACUnit.defaultUnit];
+    [falseSubject sendNext:RACUnit.defaultUnit];
 
-		expect(values).to(equal(@[]));
-		expect(lastError).to(beNil());
-		expect(@(completed)).to(beFalsy());
-	});
+    expect(values).to(equal(@[]));
+    expect(lastError).to(beNil());
+    expect(@(completed)).to(beFalsy());
+  });
 
-	qck_it(@"should send events based on the latest boolean", ^{
-		[boolSubject sendNext:@YES];
+  qck_it(@"should send events based on the latest boolean", ^{
+    [boolSubject sendNext:@YES];
 
-		[trueSubject sendNext:@"foo"];
-		[falseSubject sendNext:@"buzz"];
-		[trueSubject sendNext:@"bar"];
+    [trueSubject sendNext:@"foo"];
+    [falseSubject sendNext:@"buzz"];
+    [trueSubject sendNext:@"bar"];
 
-		NSArray *expected = @[ @"foo", @"bar" ];
-		expect(values).to(equal(expected));
-		expect(lastError).to(beNil());
-		expect(@(completed)).to(beFalsy());
+    NSArray *expected = @[ @"foo", @"bar" ];
+    expect(values).to(equal(expected));
+    expect(lastError).to(beNil());
+    expect(@(completed)).to(beFalsy());
 
-		[boolSubject sendNext:@NO];
+    [boolSubject sendNext:@NO];
 
-		[trueSubject sendNext:@"baz"];
-		[falseSubject sendNext:@"buzz"];
-		[trueSubject sendNext:@"barfoo"];
+    [trueSubject sendNext:@"baz"];
+    [falseSubject sendNext:@"buzz"];
+    [trueSubject sendNext:@"barfoo"];
 
-		expected = @[ @"foo", @"bar", @"buzz" ];
-		expect(values).to(equal(expected));
-		expect(lastError).to(beNil());
-		expect(@(completed)).to(beFalsy());
+    expected = @[ @"foo", @"bar", @"buzz" ];
+    expect(values).to(equal(expected));
+    expect(lastError).to(beNil());
+    expect(@(completed)).to(beFalsy());
 
-		[trueSubject sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
-		expect(lastError).to(beNil());
+    [trueSubject sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
+    expect(lastError).to(beNil());
 
-		[falseSubject sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
-		expect(lastError).notTo(beNil());
-	});
+    [falseSubject sendError:[NSError errorWithDomain:@"" code:-1 userInfo:nil]];
+    expect(lastError).notTo(beNil());
+  });
 
-	qck_it(@"should not send completed when only the BOOL signal completes", ^{
-		[boolSubject sendNext:@YES];
-		[trueSubject sendNext:@"foo"];
-		[boolSubject sendCompleted];
+  qck_it(@"should not send completed when only the BOOL signal completes", ^{
+    [boolSubject sendNext:@YES];
+    [trueSubject sendNext:@"foo"];
+    [boolSubject sendCompleted];
 
-		expect(values).to(equal(@[ @"foo" ]));
-		expect(@(completed)).to(beFalsy());
-	});
+    expect(values).to(equal(@[ @"foo" ]));
+    expect(@(completed)).to(beFalsy());
+  });
 
-	qck_it(@"should send completed when the BOOL signal and the latest sent signal complete", ^{
-		[boolSubject sendNext:@YES];
-		[trueSubject sendNext:@"foo"];
-		[trueSubject sendCompleted];
-		[boolSubject sendCompleted];
+  qck_it(@"should send completed when the BOOL signal and the latest sent signal complete", ^{
+    [boolSubject sendNext:@YES];
+    [trueSubject sendNext:@"foo"];
+    [trueSubject sendCompleted];
+    [boolSubject sendCompleted];
 
-		expect(values).to(equal(@[ @"foo" ]));
-		expect(@(completed)).to(beTruthy());
-	});
+    expect(values).to(equal(@[ @"foo" ]));
+    expect(@(completed)).to(beTruthy());
+  });
 });
 
 qck_describe(@"+interval:onScheduler: and +interval:onScheduler:withLeeway:", ^{
-	static const NSTimeInterval interval = 0.1;
-	static const NSTimeInterval leeway = 0.2;
+  static const NSTimeInterval interval = 0.1;
+  static const NSTimeInterval leeway = 0.2;
 
-	__block void (^testTimer)(RACSignal *, NSNumber *, NSNumber *) = nil;
+  __block void (^testTimer)(RACSignal *, NSNumber *, NSNumber *) = nil;
 
-	qck_beforeEach(^{
-		testTimer = [^(RACSignal *timer, NSNumber *minInterval, NSNumber *leeway) {
-			__block NSUInteger nextsReceived = 0;
+  qck_beforeEach(^{
+    testTimer = [^(RACSignal *timer, NSNumber *minInterval, NSNumber *leeway) {
+      __block NSUInteger nextsReceived = 0;
 
-			NSTimeInterval startTime = NSDate.timeIntervalSinceReferenceDate;
-			[[timer take:3] subscribeNext:^(NSDate *date) {
-				++nextsReceived;
+      NSTimeInterval startTime = NSDate.timeIntervalSinceReferenceDate;
+      [[timer take:3] subscribeNext:^(NSDate *date) {
+        ++nextsReceived;
 
-				NSTimeInterval currentTime = date.timeIntervalSinceReferenceDate;
+        NSTimeInterval currentTime = date.timeIntervalSinceReferenceDate;
 
-				// Uniformly distribute the expected interval for all
-				// received values. We do this instead of saving a timestamp
-				// because a delayed interval may cause the _next_ value to
-				// send sooner than the interval.
-				NSTimeInterval expectedMinInterval = minInterval.doubleValue * nextsReceived;
-				NSTimeInterval expectedMaxInterval = expectedMinInterval + leeway.doubleValue * 3 + 0.1;
+        // Uniformly distribute the expected interval for all
+        // received values. We do this instead of saving a timestamp
+        // because a delayed interval may cause the _next_ value to
+        // send sooner than the interval.
+        NSTimeInterval expectedMinInterval = minInterval.doubleValue * nextsReceived;
+        NSTimeInterval expectedMaxInterval = expectedMinInterval + leeway.doubleValue * 3 + 0.1;
 
-				expect(@(currentTime - startTime)).to(beGreaterThanOrEqualTo(@(expectedMinInterval)));
-				expect(@(currentTime - startTime)).to(beLessThanOrEqualTo(@(expectedMaxInterval)));
-			}];
+        expect(@(currentTime - startTime)).to(beGreaterThanOrEqualTo(@(expectedMinInterval)));
+        expect(@(currentTime - startTime)).to(beLessThanOrEqualTo(@(expectedMaxInterval)));
+      }];
 
-			expect(@(nextsReceived)).toEventually(equal(@3));
-		} copy];
-	});
+      expect(@(nextsReceived)).toEventually(equal(@3));
+    } copy];
+  });
 
-	qck_describe(@"+interval:onScheduler:", ^{
-		qck_it(@"should work on the main thread scheduler", ^{
-			testTimer([RACSignal interval:interval onScheduler:RACScheduler.mainThreadScheduler], @(interval), @0);
-		});
+  qck_describe(@"+interval:onScheduler:", ^{
+    qck_it(@"should work on the main thread scheduler", ^{
+      testTimer([RACSignal interval:interval onScheduler:RACScheduler.mainThreadScheduler], @(interval), @0);
+    });
 
-		qck_it(@"should work on a background scheduler", ^{
-			testTimer([RACSignal interval:interval onScheduler:[RACScheduler scheduler]], @(interval), @0);
-		});
-	});
+    qck_it(@"should work on a background scheduler", ^{
+      testTimer([RACSignal interval:interval onScheduler:[RACScheduler scheduler]], @(interval), @0);
+    });
+  });
 
-	qck_describe(@"+interval:onScheduler:withLeeway:", ^{
-		qck_it(@"should work on the main thread scheduler", ^{
-			testTimer([RACSignal interval:interval onScheduler:RACScheduler.mainThreadScheduler withLeeway:leeway], @(interval), @(leeway));
-		});
+  qck_describe(@"+interval:onScheduler:withLeeway:", ^{
+    qck_it(@"should work on the main thread scheduler", ^{
+      testTimer([RACSignal interval:interval onScheduler:RACScheduler.mainThreadScheduler withLeeway:leeway], @(interval), @(leeway));
+    });
 
-		qck_it(@"should work on a background scheduler", ^{
-			testTimer([RACSignal interval:interval onScheduler:[RACScheduler scheduler] withLeeway:leeway], @(interval), @(leeway));
-		});
-	});
+    qck_it(@"should work on a background scheduler", ^{
+      testTimer([RACSignal interval:interval onScheduler:[RACScheduler scheduler] withLeeway:leeway], @(interval), @(leeway));
+    });
+  });
 });
 
 qck_describe(@"-timeout:onScheduler:", ^{
-	__block RACSubject *subject;
+  __block RACSubject *subject;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
-	});
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
+  });
 
-	qck_it(@"should time out", ^{
-		RACTestScheduler *scheduler = [[RACTestScheduler alloc] init];
+  qck_it(@"should time out", ^{
+    RACTestScheduler *scheduler = [[RACTestScheduler alloc] init];
 
-		__block NSError *receivedError = nil;
-		[[subject timeout:1 onScheduler:scheduler] subscribeError:^(NSError *e) {
-			receivedError = e;
-		}];
+    __block NSError *receivedError = nil;
+    [[subject timeout:1 onScheduler:scheduler] subscribeError:^(NSError *e) {
+      receivedError = e;
+    }];
 
-		expect(receivedError).to(beNil());
+    expect(receivedError).to(beNil());
 
-		[scheduler stepAll];
-		expect(receivedError).toEventuallyNot(beNil());
-		expect(receivedError.domain).to(equal(RACSignalErrorDomain));
-		expect(@(receivedError.code)).to(equal(@(RACSignalErrorTimedOut)));
-	});
+    [scheduler stepAll];
+    expect(receivedError).toEventuallyNot(beNil());
+    expect(receivedError.domain).to(equal(RACSignalErrorDomain));
+    expect(@(receivedError.code)).to(equal(@(RACSignalErrorTimedOut)));
+  });
 
-	qck_it(@"should pass through events while not timed out", ^{
-		__block id next = nil;
-		__block BOOL completed = NO;
-		[[subject timeout:1 onScheduler:RACScheduler.mainThreadScheduler] subscribeNext:^(id x) {
-			next = x;
-		} completed:^{
-			completed = YES;
-		}];
+  qck_it(@"should pass through events while not timed out", ^{
+    __block id next = nil;
+    __block BOOL completed = NO;
+    [[subject timeout:1 onScheduler:RACScheduler.mainThreadScheduler] subscribeNext:^(id x) {
+      next = x;
+    } completed:^{
+      completed = YES;
+    }];
 
-		[subject sendNext:RACUnit.defaultUnit];
-		expect(next).to(equal(RACUnit.defaultUnit));
+    [subject sendNext:RACUnit.defaultUnit];
+    expect(next).to(equal(RACUnit.defaultUnit));
 
-		[subject sendCompleted];
-		expect(@(completed)).to(beTruthy());
-	});
+    [subject sendCompleted];
+    expect(@(completed)).to(beTruthy());
+  });
 
-	qck_it(@"should not time out after disposal", ^{
-		RACTestScheduler *scheduler = [[RACTestScheduler alloc] init];
+  qck_it(@"should not time out after disposal", ^{
+    RACTestScheduler *scheduler = [[RACTestScheduler alloc] init];
 
-		__block NSError *receivedError = nil;
-		RACDisposable *disposable = [[subject timeout:1 onScheduler:scheduler] subscribeError:^(NSError *e) {
-			receivedError = e;
-		}];
+    __block NSError *receivedError = nil;
+    RACDisposable *disposable = [[subject timeout:1 onScheduler:scheduler] subscribeError:^(NSError *e) {
+      receivedError = e;
+    }];
 
-		[disposable dispose];
-		[scheduler stepAll];
-		expect(receivedError).to(beNil());
-	});
+    [disposable dispose];
+    [scheduler stepAll];
+    expect(receivedError).to(beNil());
+  });
 });
 
 qck_describe(@"-delay:", ^{
-	__block RACSubject *subject;
-	__block RACSignal *delayedSignal;
+  __block RACSubject *subject;
+  __block RACSignal *delayedSignal;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
-		delayedSignal = [subject delay:0];
-	});
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
+    delayedSignal = [subject delay:0];
+  });
 
-	qck_it(@"should delay nexts", ^{
-		__block id next = nil;
-		[delayedSignal subscribeNext:^(id x) {
-			next = x;
-		}];
+  qck_it(@"should delay nexts", ^{
+    __block id next = nil;
+    [delayedSignal subscribeNext:^(id x) {
+      next = x;
+    }];
 
-		[subject sendNext:@"foo"];
-		expect(next).to(beNil());
-		expect(next).toEventually(equal(@"foo"));
-	});
+    [subject sendNext:@"foo"];
+    expect(next).to(beNil());
+    expect(next).toEventually(equal(@"foo"));
+  });
 
-	qck_it(@"should delay completed", ^{
-		__block BOOL completed = NO;
-		[delayedSignal subscribeCompleted:^{
-			completed = YES;
-		}];
+  qck_it(@"should delay completed", ^{
+    __block BOOL completed = NO;
+    [delayedSignal subscribeCompleted:^{
+      completed = YES;
+    }];
 
-		[subject sendCompleted];
-		expect(@(completed)).to(beFalsy());
-		expect(@(completed)).toEventually(beTruthy());
-	});
+    [subject sendCompleted];
+    expect(@(completed)).to(beFalsy());
+    expect(@(completed)).toEventually(beTruthy());
+  });
 
-	qck_it(@"should not delay errors", ^{
-		__block NSError *error = nil;
-		[delayedSignal subscribeError:^(NSError *e) {
-			error = e;
-		}];
+  qck_it(@"should not delay errors", ^{
+    __block NSError *error = nil;
+    [delayedSignal subscribeError:^(NSError *e) {
+      error = e;
+    }];
 
-		[subject sendError:RACSignalTestError];
-		expect(error).to(equal(RACSignalTestError));
-	});
+    [subject sendError:RACSignalTestError];
+    expect(error).to(equal(RACSignalTestError));
+  });
 
-	qck_it(@"should cancel delayed events when disposed", ^{
-		__block id next = nil;
-		RACDisposable *disposable = [delayedSignal subscribeNext:^(id x) {
-			next = x;
-		}];
+  qck_it(@"should cancel delayed events when disposed", ^{
+    __block id next = nil;
+    RACDisposable *disposable = [delayedSignal subscribeNext:^(id x) {
+      next = x;
+    }];
 
-		[subject sendNext:@"foo"];
+    [subject sendNext:@"foo"];
 
-		__block BOOL done = NO;
-		[RACScheduler.mainThreadScheduler after:[NSDate date] schedule:^{
-			done = YES;
-		}];
+    __block BOOL done = NO;
+    [RACScheduler.mainThreadScheduler after:[NSDate date] schedule:^{
+      done = YES;
+    }];
 
-		[disposable dispose];
+    [disposable dispose];
 
-		expect(@(done)).toEventually(beTruthy());
-		expect(next).to(beNil());
-	});
+    expect(@(done)).toEventually(beTruthy());
+    expect(next).to(beNil());
+  });
 });
 
 qck_describe(@"-catch:", ^{
-	qck_it(@"should subscribe to ensuing signal on error", ^{
-		RACSubject *subject = [RACSubject subject];
+  qck_it(@"should subscribe to ensuing signal on error", ^{
+    RACSubject *subject = [RACSubject subject];
 
-		RACSignal *signal = [subject catch:^(NSError *error) {
-			return [RACSignal return:@41];
-		}];
+    RACSignal *signal = [subject catch:^(NSError *error) {
+      return [RACSignal return:@41];
+    }];
 
-		__block id value = nil;
-		[signal subscribeNext:^(id x) {
-			value = x;
-		}];
+    __block id value = nil;
+    [signal subscribeNext:^(id x) {
+      value = x;
+    }];
 
-		[subject sendError:RACSignalTestError];
-		expect(value).to(equal(@41));
-	});
+    [subject sendError:RACSignalTestError];
+    expect(value).to(equal(@41));
+  });
 
-	qck_it(@"should prevent source error from propagating", ^{
-		RACSubject *subject = [RACSubject subject];
+  qck_it(@"should prevent source error from propagating", ^{
+    RACSubject *subject = [RACSubject subject];
 
-		RACSignal *signal = [subject catch:^(NSError *error) {
-			return [RACSignal empty];
-		}];
+    RACSignal *signal = [subject catch:^(NSError *error) {
+      return [RACSignal empty];
+    }];
 
-		__block BOOL errorReceived = NO;
-		[signal subscribeError:^(NSError *error) {
-			errorReceived = YES;
-		}];
+    __block BOOL errorReceived = NO;
+    [signal subscribeError:^(NSError *error) {
+      errorReceived = YES;
+    }];
 
-		[subject sendError:RACSignalTestError];
-		expect(@(errorReceived)).to(beFalsy());
-	});
+    [subject sendError:RACSignalTestError];
+    expect(@(errorReceived)).to(beFalsy());
+  });
 
-	qck_it(@"should propagate error from ensuing signal", ^{
-		RACSubject *subject = [RACSubject subject];
+  qck_it(@"should propagate error from ensuing signal", ^{
+    RACSubject *subject = [RACSubject subject];
 
-		NSError *secondaryError = [NSError errorWithDomain:@"bubs" code:41 userInfo:nil];
-		RACSignal *signal = [subject catch:^(NSError *error) {
-			return [RACSignal error:secondaryError];
-		}];
+    NSError *secondaryError = [NSError errorWithDomain:@"bubs" code:41 userInfo:nil];
+    RACSignal *signal = [subject catch:^(NSError *error) {
+      return [RACSignal error:secondaryError];
+    }];
 
-		__block NSError *errorReceived = nil;
-		[signal subscribeError:^(NSError *error) {
-			errorReceived = error;
-		}];
+    __block NSError *errorReceived = nil;
+    [signal subscribeError:^(NSError *error) {
+      errorReceived = error;
+    }];
 
-		[subject sendError:RACSignalTestError];
-		expect(errorReceived).to(equal(secondaryError));
-	});
+    [subject sendError:RACSignalTestError];
+    expect(errorReceived).to(equal(secondaryError));
+  });
 
-	qck_it(@"should dispose ensuing signal", ^{
-		RACSubject *subject = [RACSubject subject];
+  qck_it(@"should dispose ensuing signal", ^{
+    RACSubject *subject = [RACSubject subject];
 
-		__block BOOL disposed = NO;
-		RACSignal *signal = [subject catch:^(NSError *error) {
-			return [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-				return [RACDisposable disposableWithBlock:^{
-					disposed = YES;
-				}];
-			}];
-		}];
+    __block BOOL disposed = NO;
+    RACSignal *signal = [subject catch:^(NSError *error) {
+      return [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+        return [RACDisposable disposableWithBlock:^{
+          disposed = YES;
+        }];
+      }];
+    }];
 
-		RACDisposable *disposable = [signal subscribeCompleted:^{}];
-		[subject sendError:RACSignalTestError];
-		[disposable dispose];
+    RACDisposable *disposable = [signal subscribeCompleted:^{}];
+    [subject sendError:RACSignalTestError];
+    [disposable dispose];
 
-		expect(@(disposed)).toEventually(beTruthy());
-	});
+    expect(@(disposed)).toEventually(beTruthy());
+  });
 });
 
 qck_describe(@"+try:", ^{
-	__block id value;
-	__block NSError *receivedError;
+  __block id value;
+  __block NSError *receivedError;
 
-	qck_beforeEach(^{
-		value = nil;
-		receivedError = nil;
-	});
+  qck_beforeEach(^{
+    value = nil;
+    receivedError = nil;
+  });
 
-	qck_it(@"should pass the value if it is non-nil", ^{
-		RACSignal *signal = [RACSignal try:^(NSError **error) {
-			return @"foo";
-		}];
+  qck_it(@"should pass the value if it is non-nil", ^{
+    RACSignal *signal = [RACSignal try:^(NSError **error) {
+      return @"foo";
+    }];
 
-		[signal subscribeNext:^(id x) {
-			value = x;
-		} error:^(NSError *error) {
-			receivedError = error;
-		}];
+    [signal subscribeNext:^(id x) {
+      value = x;
+    } error:^(NSError *error) {
+      receivedError = error;
+    }];
 
-		expect(value).to(equal(@"foo"));
-		expect(receivedError).to(beNil());
-	});
+    expect(value).to(equal(@"foo"));
+    expect(receivedError).to(beNil());
+  });
 
-	qck_it(@"should ignore the error if the value is non-nil", ^{
-		RACSignal *signal = [RACSignal try:^(NSError **error) {
-			if (error != nil) *error = RACSignalTestError;
+  qck_it(@"should ignore the error if the value is non-nil", ^{
+    RACSignal *signal = [RACSignal try:^(NSError **error) {
+      if (error != nil) *error = RACSignalTestError;
 
-			return @"foo";
-		}];
+      return @"foo";
+    }];
 
-		[signal subscribeNext:^(id x) {
-			value = x;
-		} error:^(NSError *error) {
-			receivedError = error;
-		}];
+    [signal subscribeNext:^(id x) {
+      value = x;
+    } error:^(NSError *error) {
+      receivedError = error;
+    }];
 
-		expect(receivedError).to(beNil());
-		expect(value).to(equal(@"foo"));
-	});
+    expect(receivedError).to(beNil());
+    expect(value).to(equal(@"foo"));
+  });
 
-	qck_it(@"should send the error if the return value is nil", ^{
-		RACSignal *signal = [RACSignal try:^id(NSError **error) {
-			if (error) *error = RACSignalTestError;
+  qck_it(@"should send the error if the return value is nil", ^{
+    RACSignal *signal = [RACSignal try:^id(NSError **error) {
+      if (error) *error = RACSignalTestError;
 
-			return nil;
-		}];
+      return nil;
+    }];
 
-		[signal subscribeNext:^(id x) {
-			value = x;
-		} error:^(NSError *error) {
-			receivedError = error;
-		}];
+    [signal subscribeNext:^(id x) {
+      value = x;
+    } error:^(NSError *error) {
+      receivedError = error;
+    }];
 
-		expect(value).to(beNil());
-		expect(receivedError).to(equal(RACSignalTestError));
-	});
+    expect(value).to(beNil());
+    expect(receivedError).to(equal(RACSignalTestError));
+  });
 });
 
 qck_describe(@"-try:", ^{
-	__block RACSubject *subject;
-	__block NSError *receivedError;
-	__block NSMutableArray *nextValues;
-	__block BOOL completed;
+  __block RACSubject *subject;
+  __block NSError *receivedError;
+  __block NSMutableArray *nextValues;
+  __block BOOL completed;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
-		nextValues = [NSMutableArray array];
-		completed = NO;
-		receivedError = nil;
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
+    nextValues = [NSMutableArray array];
+    completed = NO;
+    receivedError = nil;
 
-		[[subject try:^(NSString *value, NSError **error) {
-			if (value != nil) return YES;
+    [[subject try:^(NSString *value, NSError **error) {
+      if (value != nil) return YES;
 
-			if (error != nil) *error = RACSignalTestError;
+      if (error != nil) *error = RACSignalTestError;
 
-			return NO;
-		}] subscribeNext:^(id x) {
-			[nextValues addObject:x];
-		} error:^(NSError *error) {
-			receivedError = error;
-		} completed:^{
-			completed = YES;
-		}];
-	});
+      return NO;
+    }] subscribeNext:^(id x) {
+      [nextValues addObject:x];
+    } error:^(NSError *error) {
+      receivedError = error;
+    } completed:^{
+      completed = YES;
+    }];
+  });
 
-	qck_it(@"should pass values while YES is returned from the tryBlock", ^{
-		[subject sendNext:@"foo"];
-		[subject sendNext:@"bar"];
-		[subject sendNext:@"baz"];
-		[subject sendNext:@"buzz"];
-		[subject sendCompleted];
+  qck_it(@"should pass values while YES is returned from the tryBlock", ^{
+    [subject sendNext:@"foo"];
+    [subject sendNext:@"bar"];
+    [subject sendNext:@"baz"];
+    [subject sendNext:@"buzz"];
+    [subject sendCompleted];
 
-		NSArray *receivedValues = [nextValues copy];
-		NSArray *expectedValues = @[ @"foo", @"bar", @"baz", @"buzz" ];
+    NSArray *receivedValues = [nextValues copy];
+    NSArray *expectedValues = @[ @"foo", @"bar", @"baz", @"buzz" ];
 
-		expect(receivedError).to(beNil());
-		expect(receivedValues).to(equal(expectedValues));
-		expect(@(completed)).to(beTruthy());
-	});
+    expect(receivedError).to(beNil());
+    expect(receivedValues).to(equal(expectedValues));
+    expect(@(completed)).to(beTruthy());
+  });
 
-	qck_it(@"should pass values until NO is returned from the tryBlock", ^{
-		[subject sendNext:@"foo"];
-		[subject sendNext:@"bar"];
-		[subject sendNext:nil];
-		[subject sendNext:@"buzz"];
-		[subject sendCompleted];
+  qck_it(@"should pass values until NO is returned from the tryBlock", ^{
+    [subject sendNext:@"foo"];
+    [subject sendNext:@"bar"];
+    [subject sendNext:nil];
+    [subject sendNext:@"buzz"];
+    [subject sendCompleted];
 
-		NSArray *receivedValues = [nextValues copy];
-		NSArray *expectedValues = @[ @"foo", @"bar" ];
+    NSArray *receivedValues = [nextValues copy];
+    NSArray *expectedValues = @[ @"foo", @"bar" ];
 
-		expect(receivedError).to(equal(RACSignalTestError));
-		expect(receivedValues).to(equal(expectedValues));
-		expect(@(completed)).to(beFalsy());
-	});
+    expect(receivedError).to(equal(RACSignalTestError));
+    expect(receivedValues).to(equal(expectedValues));
+    expect(@(completed)).to(beFalsy());
+  });
 });
 
 qck_describe(@"-tryMap:", ^{
-	__block RACSubject *subject;
-	__block NSError *receivedError;
-	__block NSMutableArray *nextValues;
-	__block BOOL completed;
+  __block RACSubject *subject;
+  __block NSError *receivedError;
+  __block NSMutableArray *nextValues;
+  __block BOOL completed;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
-		nextValues = [NSMutableArray array];
-		completed = NO;
-		receivedError = nil;
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
+    nextValues = [NSMutableArray array];
+    completed = NO;
+    receivedError = nil;
 
-		[[subject tryMap:^ id (NSString *value, NSError **error) {
-			if (value != nil) return [NSString stringWithFormat:@"%@_a", value];
+    [[subject tryMap:^ id (NSString *value, NSError **error) {
+      if (value != nil) return [NSString stringWithFormat:@"%@_a", value];
 
-			if (error != nil) *error = RACSignalTestError;
+      if (error != nil) *error = RACSignalTestError;
 
-			return nil;
-		}] subscribeNext:^(id x) {
-			[nextValues addObject:x];
-		} error:^(NSError *error) {
-			receivedError = error;
-		} completed:^{
-			completed = YES;
-		}];
-	});
+      return nil;
+    }] subscribeNext:^(id x) {
+      [nextValues addObject:x];
+    } error:^(NSError *error) {
+      receivedError = error;
+    } completed:^{
+      completed = YES;
+    }];
+  });
 
-	qck_it(@"should map values with the mapBlock", ^{
-		[subject sendNext:@"foo"];
-		[subject sendNext:@"bar"];
-		[subject sendNext:@"baz"];
-		[subject sendNext:@"buzz"];
-		[subject sendCompleted];
+  qck_it(@"should map values with the mapBlock", ^{
+    [subject sendNext:@"foo"];
+    [subject sendNext:@"bar"];
+    [subject sendNext:@"baz"];
+    [subject sendNext:@"buzz"];
+    [subject sendCompleted];
 
-		NSArray *receivedValues = [nextValues copy];
-		NSArray *expectedValues = @[ @"foo_a", @"bar_a", @"baz_a", @"buzz_a" ];
+    NSArray *receivedValues = [nextValues copy];
+    NSArray *expectedValues = @[ @"foo_a", @"bar_a", @"baz_a", @"buzz_a" ];
 
-		expect(receivedError).to(beNil());
-		expect(receivedValues).to(equal(expectedValues));
-		expect(@(completed)).to(beTruthy());
-	});
+    expect(receivedError).to(beNil());
+    expect(receivedValues).to(equal(expectedValues));
+    expect(@(completed)).to(beTruthy());
+  });
 
-	qck_it(@"should map values with the mapBlock, until the mapBlock returns nil", ^{
-		[subject sendNext:@"foo"];
-		[subject sendNext:@"bar"];
-		[subject sendNext:nil];
-		[subject sendNext:@"buzz"];
-		[subject sendCompleted];
+  qck_it(@"should map values with the mapBlock, until the mapBlock returns nil", ^{
+    [subject sendNext:@"foo"];
+    [subject sendNext:@"bar"];
+    [subject sendNext:nil];
+    [subject sendNext:@"buzz"];
+    [subject sendCompleted];
 
-		NSArray *receivedValues = [nextValues copy];
-		NSArray *expectedValues = @[ @"foo_a", @"bar_a" ];
+    NSArray *receivedValues = [nextValues copy];
+    NSArray *expectedValues = @[ @"foo_a", @"bar_a" ];
 
-		expect(receivedError).to(equal(RACSignalTestError));
-		expect(receivedValues).to(equal(expectedValues));
-		expect(@(completed)).to(beFalsy());
-	});
+    expect(receivedError).to(equal(RACSignalTestError));
+    expect(receivedValues).to(equal(expectedValues));
+    expect(@(completed)).to(beFalsy());
+  });
 });
 
 qck_describe(@"throttling", ^{
-	__block RACSubject *subject;
+  __block RACSubject *subject;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
-	});
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
+  });
 
-	qck_describe(@"-throttle:", ^{
-		__block RACSignal *throttledSignal;
+  qck_describe(@"-throttle:", ^{
+    __block RACSignal *throttledSignal;
 
-		qck_beforeEach(^{
-			throttledSignal = [subject throttle:0];
-		});
+    qck_beforeEach(^{
+      throttledSignal = [subject throttle:0];
+    });
 
-		qck_it(@"should throttle nexts", ^{
-			NSMutableArray *valuesReceived = [NSMutableArray array];
-			[throttledSignal subscribeNext:^(id x) {
-				[valuesReceived addObject:x];
-			}];
+    qck_it(@"should throttle nexts", ^{
+      NSMutableArray *valuesReceived = [NSMutableArray array];
+      [throttledSignal subscribeNext:^(id x) {
+        [valuesReceived addObject:x];
+      }];
 
-			[subject sendNext:@"foo"];
-			[subject sendNext:@"bar"];
-			expect(valuesReceived).to(equal(@[]));
+      [subject sendNext:@"foo"];
+      [subject sendNext:@"bar"];
+      expect(valuesReceived).to(equal(@[]));
 
-			NSArray *expected = @[ @"bar" ];
-			expect(valuesReceived).toEventually(equal(expected));
+      NSArray *expected = @[ @"bar" ];
+      expect(valuesReceived).toEventually(equal(expected));
 
-			[subject sendNext:@"buzz"];
-			expect(valuesReceived).to(equal(expected));
+      [subject sendNext:@"buzz"];
+      expect(valuesReceived).to(equal(expected));
 
-			expected = @[ @"bar", @"buzz" ];
-			expect(valuesReceived).toEventually(equal(expected));
-		});
+      expected = @[ @"bar", @"buzz" ];
+      expect(valuesReceived).toEventually(equal(expected));
+    });
 
-		qck_it(@"should forward completed immediately", ^{
-			__block BOOL completed = NO;
-			[throttledSignal subscribeCompleted:^{
-				completed = YES;
-			}];
+    qck_it(@"should forward completed immediately", ^{
+      __block BOOL completed = NO;
+      [throttledSignal subscribeCompleted:^{
+        completed = YES;
+      }];
 
-			[subject sendCompleted];
-			expect(@(completed)).to(beTruthy());
-		});
+      [subject sendCompleted];
+      expect(@(completed)).to(beTruthy());
+    });
 
-		qck_it(@"should forward errors immediately", ^{
-			__block NSError *error = nil;
-			[throttledSignal subscribeError:^(NSError *e) {
-				error = e;
-			}];
+    qck_it(@"should forward errors immediately", ^{
+      __block NSError *error = nil;
+      [throttledSignal subscribeError:^(NSError *e) {
+        error = e;
+      }];
 
-			[subject sendError:RACSignalTestError];
-			expect(error).to(equal(RACSignalTestError));
-		});
+      [subject sendError:RACSignalTestError];
+      expect(error).to(equal(RACSignalTestError));
+    });
 
-		qck_it(@"should cancel future nexts when disposed", ^{
-			__block id next = nil;
-			RACDisposable *disposable = [throttledSignal subscribeNext:^(id x) {
-				next = x;
-			}];
+    qck_it(@"should cancel future nexts when disposed", ^{
+      __block id next = nil;
+      RACDisposable *disposable = [throttledSignal subscribeNext:^(id x) {
+        next = x;
+      }];
 
-			[subject sendNext:@"foo"];
+      [subject sendNext:@"foo"];
 
-			__block BOOL done = NO;
-			[RACScheduler.mainThreadScheduler after:[NSDate date] schedule:^{
-				done = YES;
-			}];
+      __block BOOL done = NO;
+      [RACScheduler.mainThreadScheduler after:[NSDate date] schedule:^{
+        done = YES;
+      }];
 
-			[disposable dispose];
+      [disposable dispose];
 
-			expect(@(done)).toEventually(beTruthy());
-			expect(next).to(beNil());
-		});
-	});
+      expect(@(done)).toEventually(beTruthy());
+      expect(next).to(beNil());
+    });
+  });
 
-	qck_describe(@"-throttle:valuesPassingTest:", ^{
-		__block RACSignal *throttledSignal;
-		__block BOOL shouldThrottle;
+  qck_describe(@"-throttle:valuesPassingTest:", ^{
+    __block RACSignal *throttledSignal;
+    __block BOOL shouldThrottle;
 
-		qck_beforeEach(^{
-			shouldThrottle = YES;
+    qck_beforeEach(^{
+      shouldThrottle = YES;
 
-			__block id value = nil;
-			throttledSignal = [[subject
-				doNext:^(id x) {
-					value = x;
-				}]
-				throttle:0 valuesPassingTest:^(id x) {
-					// Make sure that we're given the latest value.
-					expect(x).to(beIdenticalTo(value));
+      __block id value = nil;
+      throttledSignal = [[subject
+        doNext:^(id x) {
+          value = x;
+        }]
+        throttle:0 valuesPassingTest:^(id x) {
+          // Make sure that we're given the latest value.
+          expect(x).to(beIdenticalTo(value));
 
-					return shouldThrottle;
-				}];
+          return shouldThrottle;
+        }];
 
-			expect(throttledSignal).notTo(beNil());
-		});
+      expect(throttledSignal).notTo(beNil());
+    });
 
-		qck_describe(@"nexts", ^{
-			__block NSMutableArray *valuesReceived;
-			__block NSMutableArray *expected;
+    qck_describe(@"nexts", ^{
+      __block NSMutableArray *valuesReceived;
+      __block NSMutableArray *expected;
 
-			qck_beforeEach(^{
-				expected = [[NSMutableArray alloc] init];
-				valuesReceived = [[NSMutableArray alloc] init];
+      qck_beforeEach(^{
+        expected = [[NSMutableArray alloc] init];
+        valuesReceived = [[NSMutableArray alloc] init];
 
-				[throttledSignal subscribeNext:^(id x) {
-					[valuesReceived addObject:x];
-				}];
-			});
+        [throttledSignal subscribeNext:^(id x) {
+          [valuesReceived addObject:x];
+        }];
+      });
 
-			qck_it(@"should forward unthrottled values immediately", ^{
-				shouldThrottle = NO;
-				[subject sendNext:@"foo"];
+      qck_it(@"should forward unthrottled values immediately", ^{
+        shouldThrottle = NO;
+        [subject sendNext:@"foo"];
 
-				[expected addObject:@"foo"];
-				expect(valuesReceived).to(equal(expected));
-			});
+        [expected addObject:@"foo"];
+        expect(valuesReceived).to(equal(expected));
+      });
 
-			qck_it(@"should delay throttled values", ^{
-				[subject sendNext:@"bar"];
-				expect(valuesReceived).to(equal(expected));
+      qck_it(@"should delay throttled values", ^{
+        [subject sendNext:@"bar"];
+        expect(valuesReceived).to(equal(expected));
 
-				[expected addObject:@"bar"];
-				expect(valuesReceived).toEventually(equal(expected));
-			});
+        [expected addObject:@"bar"];
+        expect(valuesReceived).toEventually(equal(expected));
+      });
 
-			qck_it(@"should drop buffered values when a throttled value arrives", ^{
-				[subject sendNext:@"foo"];
-				[subject sendNext:@"bar"];
-				[subject sendNext:@"buzz"];
-				expect(valuesReceived).to(equal(expected));
+      qck_it(@"should drop buffered values when a throttled value arrives", ^{
+        [subject sendNext:@"foo"];
+        [subject sendNext:@"bar"];
+        [subject sendNext:@"buzz"];
+        expect(valuesReceived).to(equal(expected));
 
-				[expected addObject:@"buzz"];
-				expect(valuesReceived).toEventually(equal(expected));
-			});
+        [expected addObject:@"buzz"];
+        expect(valuesReceived).toEventually(equal(expected));
+      });
 
-			qck_it(@"should drop buffered values when an immediate value arrives", ^{
-				[subject sendNext:@"foo"];
-				[subject sendNext:@"bar"];
+      qck_it(@"should drop buffered values when an immediate value arrives", ^{
+        [subject sendNext:@"foo"];
+        [subject sendNext:@"bar"];
 
-				shouldThrottle = NO;
-				[subject sendNext:@"buzz"];
-				[expected addObject:@"buzz"];
-				expect(valuesReceived).to(equal(expected));
+        shouldThrottle = NO;
+        [subject sendNext:@"buzz"];
+        [expected addObject:@"buzz"];
+        expect(valuesReceived).to(equal(expected));
 
-				// Make sure that nothing weird happens when sending another
-				// throttled value.
-				shouldThrottle = YES;
-				[subject sendNext:@"baz"];
-				expect(valuesReceived).to(equal(expected));
+        // Make sure that nothing weird happens when sending another
+        // throttled value.
+        shouldThrottle = YES;
+        [subject sendNext:@"baz"];
+        expect(valuesReceived).to(equal(expected));
 
-				[expected addObject:@"baz"];
-				expect(valuesReceived).toEventually(equal(expected));
-			});
+        [expected addObject:@"baz"];
+        expect(valuesReceived).toEventually(equal(expected));
+      });
 
-			qck_it(@"should not be resent upon completion", ^{
-				[subject sendNext:@"bar"];
-				[expected addObject:@"bar"];
-				expect(valuesReceived).toEventually(equal(expected));
+      qck_it(@"should not be resent upon completion", ^{
+        [subject sendNext:@"bar"];
+        [expected addObject:@"bar"];
+        expect(valuesReceived).toEventually(equal(expected));
 
-				[subject sendCompleted];
-				expect(valuesReceived).to(equal(expected));
-			});
-		});
+        [subject sendCompleted];
+        expect(valuesReceived).to(equal(expected));
+      });
+    });
 
-		qck_it(@"should forward completed immediately", ^{
-			__block BOOL completed = NO;
-			[throttledSignal subscribeCompleted:^{
-				completed = YES;
-			}];
+    qck_it(@"should forward completed immediately", ^{
+      __block BOOL completed = NO;
+      [throttledSignal subscribeCompleted:^{
+        completed = YES;
+      }];
 
-			[subject sendCompleted];
-			expect(@(completed)).to(beTruthy());
-		});
+      [subject sendCompleted];
+      expect(@(completed)).to(beTruthy());
+    });
 
-		qck_it(@"should forward errors immediately", ^{
-			__block NSError *error = nil;
-			[throttledSignal subscribeError:^(NSError *e) {
-				error = e;
-			}];
+    qck_it(@"should forward errors immediately", ^{
+      __block NSError *error = nil;
+      [throttledSignal subscribeError:^(NSError *e) {
+        error = e;
+      }];
 
-			[subject sendError:RACSignalTestError];
-			expect(error).to(equal(RACSignalTestError));
-		});
+      [subject sendError:RACSignalTestError];
+      expect(error).to(equal(RACSignalTestError));
+    });
 
-		qck_it(@"should cancel future nexts when disposed", ^{
-			__block id next = nil;
-			RACDisposable *disposable = [throttledSignal subscribeNext:^(id x) {
-				next = x;
-			}];
+    qck_it(@"should cancel future nexts when disposed", ^{
+      __block id next = nil;
+      RACDisposable *disposable = [throttledSignal subscribeNext:^(id x) {
+        next = x;
+      }];
 
-			[subject sendNext:@"foo"];
+      [subject sendNext:@"foo"];
 
-			__block BOOL done = NO;
-			[RACScheduler.mainThreadScheduler after:[NSDate date] schedule:^{
-				done = YES;
-			}];
+      __block BOOL done = NO;
+      [RACScheduler.mainThreadScheduler after:[NSDate date] schedule:^{
+        done = YES;
+      }];
 
-			[disposable dispose];
+      [disposable dispose];
 
-			expect(@(done)).toEventually(beTruthy());
-			expect(next).to(beNil());
-		});
-	});
+      expect(@(done)).toEventually(beTruthy());
+      expect(next).to(beNil());
+    });
+  });
 });
 
 qck_describe(@"-then:", ^{
-	qck_it(@"should continue onto returned signal", ^{
-		RACSubject *subject = [RACSubject subject];
+  qck_it(@"should continue onto returned signal", ^{
+    RACSubject *subject = [RACSubject subject];
 
-		__block id value = nil;
-		[[subject then:^{
-			return [RACSignal return:@2];
-		}] subscribeNext:^(id x) {
-			value = x;
-		}];
+    __block id value = nil;
+    [[subject then:^{
+      return [RACSignal return:@2];
+    }] subscribeNext:^(id x) {
+      value = x;
+    }];
 
-		[subject sendNext:@1];
+    [subject sendNext:@1];
 
-		// The value shouldn't change until the first signal completes.
-		expect(value).to(beNil());
+    // The value shouldn't change until the first signal completes.
+    expect(value).to(beNil());
 
-		[subject sendCompleted];
+    [subject sendCompleted];
 
-		expect(value).to(equal(@2));
-	});
+    expect(value).to(equal(@2));
+  });
 
-	qck_it(@"should sequence even if no next value is sent", ^{
-		RACSubject *subject = [RACSubject subject];
+  qck_it(@"should sequence even if no next value is sent", ^{
+    RACSubject *subject = [RACSubject subject];
 
-		__block id value = nil;
-		[[subject then:^{
-			return [RACSignal return:RACUnit.defaultUnit];
-		}] subscribeNext:^(id x) {
-			value = x;
-		}];
+    __block id value = nil;
+    [[subject then:^{
+      return [RACSignal return:RACUnit.defaultUnit];
+    }] subscribeNext:^(id x) {
+      value = x;
+    }];
 
-		[subject sendCompleted];
+    [subject sendCompleted];
 
-		expect(value).to(equal(RACUnit.defaultUnit));
-	});
+    expect(value).to(equal(RACUnit.defaultUnit));
+  });
 });
 
 qck_describe(@"-sequence", ^{
-	RACSignal *signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-		[subscriber sendNext:@1];
-		[subscriber sendNext:@2];
-		[subscriber sendNext:@3];
-		[subscriber sendNext:@4];
-		[subscriber sendCompleted];
-		return nil;
-	}];
+  RACSignal *signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+    [subscriber sendNext:@1];
+    [subscriber sendNext:@2];
+    [subscriber sendNext:@3];
+    [subscriber sendNext:@4];
+    [subscriber sendCompleted];
+    return nil;
+  }];
 
-	qck_itBehavesLike(RACSequenceExamples, ^{
-		return @{
-			RACSequenceExampleSequence: signal.sequence,
-			RACSequenceExampleExpectedValues: @[ @1, @2, @3, @4 ]
-		};
-	});
+  qck_itBehavesLike(RACSequenceExamples, ^{
+    return @{
+      RACSequenceExampleSequence: signal.sequence,
+      RACSequenceExampleExpectedValues: @[ @1, @2, @3, @4 ]
+    };
+  });
 });
 
 qck_it(@"should complete take: even if the original signal doesn't", ^{
-	RACSignal *sendOne = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-		[subscriber sendNext:RACUnit.defaultUnit];
-		return nil;
-	}];
+  RACSignal *sendOne = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+    [subscriber sendNext:RACUnit.defaultUnit];
+    return nil;
+  }];
 
-	__block id value = nil;
-	__block BOOL completed = NO;
-	[[sendOne take:1] subscribeNext:^(id received) {
-		value = received;
-	} completed:^{
-		completed = YES;
-	}];
+  __block id value = nil;
+  __block BOOL completed = NO;
+  [[sendOne take:1] subscribeNext:^(id received) {
+    value = received;
+  } completed:^{
+    completed = YES;
+  }];
 
-	expect(value).to(equal(RACUnit.defaultUnit));
-	expect(@(completed)).to(beTruthy());
+  expect(value).to(equal(RACUnit.defaultUnit));
+  expect(@(completed)).to(beTruthy());
 });
 
 qck_it(@"should complete take: even if the signal is recursive", ^{
-	RACSubject *subject = [RACSubject subject];
-	const NSUInteger number = 3;
-	const NSUInteger guard = number + 1;
+  RACSubject *subject = [RACSubject subject];
+  const NSUInteger number = 3;
+  const NSUInteger guard = number + 1;
 
-	NSMutableArray *values = NSMutableArray.array;
-	__block BOOL completed = NO;
+  NSMutableArray *values = NSMutableArray.array;
+  __block BOOL completed = NO;
 
-	[[subject take:number] subscribeNext:^(NSNumber* received) {
-		[values addObject:received];
-		if (values.count >= guard) {
-			[subject sendError:RACSignalTestError];
-		}
-		[subject sendNext:@(received.integerValue + 1)];
-	} completed:^{
-		completed = YES;
-	}];
-	[subject sendNext:@0];
+  [[subject take:number] subscribeNext:^(NSNumber* received) {
+    [values addObject:received];
+    if (values.count >= guard) {
+      [subject sendError:RACSignalTestError];
+    }
+    [subject sendNext:@(received.integerValue + 1)];
+  } completed:^{
+    completed = YES;
+  }];
+  [subject sendNext:@0];
 
-	NSMutableArray* expectedValues = [NSMutableArray arrayWithCapacity:number];
-	for (NSUInteger i = 0 ; i < number ; ++i) {
-		[expectedValues addObject:@(i)];
-	}
+  NSMutableArray* expectedValues = [NSMutableArray arrayWithCapacity:number];
+  for (NSUInteger i = 0 ; i < number ; ++i) {
+    [expectedValues addObject:@(i)];
+  }
 
-	expect(values).to(equal(expectedValues));
-	expect(@(completed)).to(beTruthy());
+  expect(values).to(equal(expectedValues));
+  expect(@(completed)).to(beTruthy());
 });
 
 qck_describe(@"+zip:", ^{
-	__block RACSubject *subject1 = nil;
-	__block RACSubject *subject2 = nil;
-	__block BOOL hasSentError = NO;
-	__block BOOL hasSentCompleted = NO;
-	__block RACDisposable *disposable = nil;
-	__block void (^send2NextAndErrorTo1)(void) = nil;
-	__block void (^send3NextAndErrorTo1)(void) = nil;
-	__block void (^send2NextAndCompletedTo2)(void) = nil;
-	__block void (^send3NextAndCompletedTo2)(void) = nil;
+  __block RACSubject *subject1 = nil;
+  __block RACSubject *subject2 = nil;
+  __block BOOL hasSentError = NO;
+  __block BOOL hasSentCompleted = NO;
+  __block RACDisposable *disposable = nil;
+  __block void (^send2NextAndErrorTo1)(void) = nil;
+  __block void (^send3NextAndErrorTo1)(void) = nil;
+  __block void (^send2NextAndCompletedTo2)(void) = nil;
+  __block void (^send3NextAndCompletedTo2)(void) = nil;
 
-	qck_beforeEach(^{
-		send2NextAndErrorTo1 = [^{
-			[subject1 sendNext:@1];
-			[subject1 sendNext:@2];
-			[subject1 sendError:RACSignalTestError];
-		} copy];
-		send3NextAndErrorTo1 = [^{
-			[subject1 sendNext:@1];
-			[subject1 sendNext:@2];
-			[subject1 sendNext:@3];
-			[subject1 sendError:RACSignalTestError];
-		} copy];
-		send2NextAndCompletedTo2 = [^{
-			[subject2 sendNext:@1];
-			[subject2 sendNext:@2];
-			[subject2 sendCompleted];
-		} copy];
-		send3NextAndCompletedTo2 = [^{
-			[subject2 sendNext:@1];
-			[subject2 sendNext:@2];
-			[subject2 sendNext:@3];
-			[subject2 sendCompleted];
-		} copy];
-		subject1 = [RACSubject subject];
-		subject2 = [RACSubject subject];
-		hasSentError = NO;
-		hasSentCompleted = NO;
-		disposable = [[RACSignal zip:@[ subject1, subject2 ]] subscribeError:^(NSError *error) {
-			hasSentError = YES;
-		} completed:^{
-			hasSentCompleted = YES;
-		}];
-	});
+  qck_beforeEach(^{
+    send2NextAndErrorTo1 = [^{
+      [subject1 sendNext:@1];
+      [subject1 sendNext:@2];
+      [subject1 sendError:RACSignalTestError];
+    } copy];
+    send3NextAndErrorTo1 = [^{
+      [subject1 sendNext:@1];
+      [subject1 sendNext:@2];
+      [subject1 sendNext:@3];
+      [subject1 sendError:RACSignalTestError];
+    } copy];
+    send2NextAndCompletedTo2 = [^{
+      [subject2 sendNext:@1];
+      [subject2 sendNext:@2];
+      [subject2 sendCompleted];
+    } copy];
+    send3NextAndCompletedTo2 = [^{
+      [subject2 sendNext:@1];
+      [subject2 sendNext:@2];
+      [subject2 sendNext:@3];
+      [subject2 sendCompleted];
+    } copy];
+    subject1 = [RACSubject subject];
+    subject2 = [RACSubject subject];
+    hasSentError = NO;
+    hasSentCompleted = NO;
+    disposable = [[RACSignal zip:@[ subject1, subject2 ]] subscribeError:^(NSError *error) {
+      hasSentError = YES;
+    } completed:^{
+      hasSentCompleted = YES;
+    }];
+  });
 
-	qck_afterEach(^{
-		[disposable dispose];
-	});
+  qck_afterEach(^{
+    [disposable dispose];
+  });
 
-	qck_it(@"should complete as soon as no new zipped values are possible", ^{
-		[subject1 sendNext:@1];
-		[subject2 sendNext:@1];
-		expect(@(hasSentCompleted)).to(beFalsy());
+  qck_it(@"should complete as soon as no new zipped values are possible", ^{
+    [subject1 sendNext:@1];
+    [subject2 sendNext:@1];
+    expect(@(hasSentCompleted)).to(beFalsy());
 
-		[subject1 sendNext:@2];
-		[subject1 sendCompleted];
-		expect(@(hasSentCompleted)).to(beFalsy());
+    [subject1 sendNext:@2];
+    [subject1 sendCompleted];
+    expect(@(hasSentCompleted)).to(beFalsy());
 
-		[subject2 sendNext:@2];
-		expect(@(hasSentCompleted)).to(beTruthy());
-	});
+    [subject2 sendNext:@2];
+    expect(@(hasSentCompleted)).to(beTruthy());
+  });
 
-	qck_it(@"outcome should not be dependent on order of signals", ^{
-		[subject2 sendCompleted];
-		expect(@(hasSentCompleted)).to(beTruthy());
-	});
+  qck_it(@"outcome should not be dependent on order of signals", ^{
+    [subject2 sendCompleted];
+    expect(@(hasSentCompleted)).to(beTruthy());
+  });
 
-	qck_it(@"should forward errors sent earlier than (time-wise) and before (position-wise) a complete", ^{
-		send2NextAndErrorTo1();
-		send3NextAndCompletedTo2();
-		expect(@(hasSentError)).to(beTruthy());
-		expect(@(hasSentCompleted)).to(beFalsy());
-	});
+  qck_it(@"should forward errors sent earlier than (time-wise) and before (position-wise) a complete", ^{
+    send2NextAndErrorTo1();
+    send3NextAndCompletedTo2();
+    expect(@(hasSentError)).to(beTruthy());
+    expect(@(hasSentCompleted)).to(beFalsy());
+  });
 
-	qck_it(@"should forward errors sent earlier than (time-wise) and after (position-wise) a complete", ^{
-		send3NextAndErrorTo1();
-		send2NextAndCompletedTo2();
-		expect(@(hasSentError)).to(beTruthy());
-		expect(@(hasSentCompleted)).to(beFalsy());
-	});
+  qck_it(@"should forward errors sent earlier than (time-wise) and after (position-wise) a complete", ^{
+    send3NextAndErrorTo1();
+    send2NextAndCompletedTo2();
+    expect(@(hasSentError)).to(beTruthy());
+    expect(@(hasSentCompleted)).to(beFalsy());
+  });
 
-	qck_it(@"should forward errors sent later than (time-wise) and before (position-wise) a complete", ^{
-		send3NextAndCompletedTo2();
-		send2NextAndErrorTo1();
-		expect(@(hasSentError)).to(beTruthy());
-		expect(@(hasSentCompleted)).to(beFalsy());
-	});
+  qck_it(@"should forward errors sent later than (time-wise) and before (position-wise) a complete", ^{
+    send3NextAndCompletedTo2();
+    send2NextAndErrorTo1();
+    expect(@(hasSentError)).to(beTruthy());
+    expect(@(hasSentCompleted)).to(beFalsy());
+  });
 
-	qck_it(@"should ignore errors sent later than (time-wise) and after (position-wise) a complete", ^{
-		send2NextAndCompletedTo2();
-		send3NextAndErrorTo1();
-		expect(@(hasSentError)).to(beFalsy());
-		expect(@(hasSentCompleted)).to(beTruthy());
-	});
+  qck_it(@"should ignore errors sent later than (time-wise) and after (position-wise) a complete", ^{
+    send2NextAndCompletedTo2();
+    send3NextAndErrorTo1();
+    expect(@(hasSentError)).to(beFalsy());
+    expect(@(hasSentCompleted)).to(beTruthy());
+  });
 
-	qck_it(@"should handle signals sending values unevenly", ^{
-		__block NSError *receivedError = nil;
-		__block BOOL hasCompleted = NO;
+  qck_it(@"should handle signals sending values unevenly", ^{
+    __block NSError *receivedError = nil;
+    __block BOOL hasCompleted = NO;
 
-		RACSubject *a = [RACSubject subject];
-		RACSubject *b = [RACSubject subject];
-		RACSubject *c = [RACSubject subject];
+    RACSubject *a = [RACSubject subject];
+    RACSubject *b = [RACSubject subject];
+    RACSubject *c = [RACSubject subject];
 
-		NSMutableArray *receivedValues = NSMutableArray.array;
-		NSArray *expectedValues = nil;
+    NSMutableArray *receivedValues = NSMutableArray.array;
+    NSArray *expectedValues = nil;
 
-		[[RACSignal zip:@[ a, b, c ] reduce:^(NSNumber *a, NSNumber *b, NSNumber *c) {
-			return [NSString stringWithFormat:@"%@%@%@", a, b, c];
-		}] subscribeNext:^(id x) {
-			[receivedValues addObject:x];
-		} error:^(NSError *error) {
-			receivedError = error;
-		} completed:^{
-			hasCompleted = YES;
-		}];
+    [[RACSignal zip:@[ a, b, c ] reduce:^(NSNumber *a, NSNumber *b, NSNumber *c) {
+      return [NSString stringWithFormat:@"%@%@%@", a, b, c];
+    }] subscribeNext:^(id x) {
+      [receivedValues addObject:x];
+    } error:^(NSError *error) {
+      receivedError = error;
+    } completed:^{
+      hasCompleted = YES;
+    }];
 
-		[a sendNext:@1];
-		[a sendNext:@2];
-		[a sendNext:@3];
+    [a sendNext:@1];
+    [a sendNext:@2];
+    [a sendNext:@3];
 
-		[b sendNext:@1];
+    [b sendNext:@1];
 
-		[c sendNext:@1];
-		[c sendNext:@2];
+    [c sendNext:@1];
+    [c sendNext:@2];
 
-		// a: [===......]
-		// b: [=........]
-		// c: [==.......]
+    // a: [===......]
+    // b: [=........]
+    // c: [==.......]
 
-		expectedValues = @[ @"111" ];
-		expect(receivedValues).to(equal(expectedValues));
-		expect(receivedError).to(beNil());
-		expect(@(hasCompleted)).to(beFalsy());
+    expectedValues = @[ @"111" ];
+    expect(receivedValues).to(equal(expectedValues));
+    expect(receivedError).to(beNil());
+    expect(@(hasCompleted)).to(beFalsy());
 
-		[b sendNext:@2];
-		[b sendNext:@3];
-		[b sendNext:@4];
-		[b sendCompleted];
+    [b sendNext:@2];
+    [b sendNext:@3];
+    [b sendNext:@4];
+    [b sendCompleted];
 
-		// a: [===......]
-		// b: [====C....]
-		// c: [==.......]
+    // a: [===......]
+    // b: [====C....]
+    // c: [==.......]
 
-		expectedValues = @[ @"111", @"222" ];
-		expect(receivedValues).to(equal(expectedValues));
-		expect(receivedError).to(beNil());
-		expect(@(hasCompleted)).to(beFalsy());
+    expectedValues = @[ @"111", @"222" ];
+    expect(receivedValues).to(equal(expectedValues));
+    expect(receivedError).to(beNil());
+    expect(@(hasCompleted)).to(beFalsy());
 
-		[c sendNext:@3];
-		[c sendNext:@4];
-		[c sendNext:@5];
-		[c sendError:RACSignalTestError];
+    [c sendNext:@3];
+    [c sendNext:@4];
+    [c sendNext:@5];
+    [c sendError:RACSignalTestError];
 
-		// a: [===......]
-		// b: [====C....]
-		// c: [=====E...]
+    // a: [===......]
+    // b: [====C....]
+    // c: [=====E...]
 
-		expectedValues = @[ @"111", @"222", @"333" ];
-		expect(receivedValues).to(equal(expectedValues));
-		expect(receivedError).to(equal(RACSignalTestError));
-		expect(@(hasCompleted)).to(beFalsy());
+    expectedValues = @[ @"111", @"222", @"333" ];
+    expect(receivedValues).to(equal(expectedValues));
+    expect(receivedError).to(equal(RACSignalTestError));
+    expect(@(hasCompleted)).to(beFalsy());
 
-		[a sendNext:@4];
-		[a sendNext:@5];
-		[a sendNext:@6];
-		[a sendNext:@7];
+    [a sendNext:@4];
+    [a sendNext:@5];
+    [a sendNext:@6];
+    [a sendNext:@7];
 
-		// a: [=======..]
-		// b: [====C....]
-		// c: [=====E...]
+    // a: [=======..]
+    // b: [====C....]
+    // c: [=====E...]
 
-		expectedValues = @[ @"111", @"222", @"333" ];
-		expect(receivedValues).to(equal(expectedValues));
-		expect(receivedError).to(equal(RACSignalTestError));
-		expect(@(hasCompleted)).to(beFalsy());
-	});
+    expectedValues = @[ @"111", @"222", @"333" ];
+    expect(receivedValues).to(equal(expectedValues));
+    expect(receivedError).to(equal(RACSignalTestError));
+    expect(@(hasCompleted)).to(beFalsy());
+  });
 
-	qck_it(@"should handle multiples of the same side-effecting signal", ^{
-		__block NSUInteger counter = 0;
-		RACSignal *sideEffectingSignal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			++counter;
-			[subscriber sendNext:@1];
-			[subscriber sendCompleted];
-			return nil;
-		}];
-		RACSignal *combined = [RACSignal zip:@[ sideEffectingSignal, sideEffectingSignal ] reduce:^ NSString * (id x, id y) {
-			return [NSString stringWithFormat:@"%@%@", x, y];
-		}];
-		NSMutableArray *receivedValues = NSMutableArray.array;
+  qck_it(@"should handle multiples of the same side-effecting signal", ^{
+    __block NSUInteger counter = 0;
+    RACSignal *sideEffectingSignal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      ++counter;
+      [subscriber sendNext:@1];
+      [subscriber sendCompleted];
+      return nil;
+    }];
+    RACSignal *combined = [RACSignal zip:@[ sideEffectingSignal, sideEffectingSignal ] reduce:^ NSString * (id x, id y) {
+      return [NSString stringWithFormat:@"%@%@", x, y];
+    }];
+    NSMutableArray *receivedValues = NSMutableArray.array;
 
-		expect(@(counter)).to(equal(@0));
+    expect(@(counter)).to(equal(@0));
 
-		[combined subscribeNext:^(id x) {
-			[receivedValues addObject:x];
-		}];
+    [combined subscribeNext:^(id x) {
+      [receivedValues addObject:x];
+    }];
 
-		expect(@(counter)).to(equal(@2));
-		expect(receivedValues).to(equal(@[ @"11" ]));
-	});
+    expect(@(counter)).to(equal(@2));
+    expect(receivedValues).to(equal(@[ @"11" ]));
+  });
 });
 
 qck_describe(@"-sample:", ^{
-	__block RACSubject *subject;
-	__block RACSubject *sampleSubject;
-	__block RACSignal *sampled;
+  __block RACSubject *subject;
+  __block RACSubject *sampleSubject;
+  __block RACSignal *sampled;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
-		sampleSubject = [RACSubject subject];
-		sampled = [subject sample:sampleSubject];
-	});
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
+    sampleSubject = [RACSubject subject];
+    sampled = [subject sample:sampleSubject];
+  });
 
-	qck_it(@"should send the latest value when the sampler signal fires", ^{
-		NSMutableArray *values = [NSMutableArray array];
-		[sampled subscribeNext:^(id x) {
-			[values addObject:x];
-		}];
+  qck_it(@"should send the latest value when the sampler signal fires", ^{
+    NSMutableArray *values = [NSMutableArray array];
+    [sampled subscribeNext:^(id x) {
+      [values addObject:x];
+    }];
 
-		[sampleSubject sendNext:RACUnit.defaultUnit];
-		expect(values).to(equal(@[]));
+    [sampleSubject sendNext:RACUnit.defaultUnit];
+    expect(values).to(equal(@[]));
 
-		[subject sendNext:@1];
-		[subject sendNext:@2];
-		expect(values).to(equal(@[]));
+    [subject sendNext:@1];
+    [subject sendNext:@2];
+    expect(values).to(equal(@[]));
 
-		[sampleSubject sendNext:RACUnit.defaultUnit];
-		NSArray *expected = @[ @2 ];
-		expect(values).to(equal(expected));
+    [sampleSubject sendNext:RACUnit.defaultUnit];
+    NSArray *expected = @[ @2 ];
+    expect(values).to(equal(expected));
 
-		[subject sendNext:@3];
-		expect(values).to(equal(expected));
+    [subject sendNext:@3];
+    expect(values).to(equal(expected));
 
-		[sampleSubject sendNext:RACUnit.defaultUnit];
-		expected = @[ @2, @3 ];
-		expect(values).to(equal(expected));
+    [sampleSubject sendNext:RACUnit.defaultUnit];
+    expected = @[ @2, @3 ];
+    expect(values).to(equal(expected));
 
-		[sampleSubject sendNext:RACUnit.defaultUnit];
-		expected = @[ @2, @3, @3 ];
-		expect(values).to(equal(expected));
-	});
+    [sampleSubject sendNext:RACUnit.defaultUnit];
+    expected = @[ @2, @3, @3 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"should not complete before sampler completes", ^{
-		__block BOOL hasCompleted = NO;
-		[sampled subscribeCompleted:^{
-			hasCompleted = YES;
-		}];
+  qck_it(@"should not complete before sampler completes", ^{
+    __block BOOL hasCompleted = NO;
+    [sampled subscribeCompleted:^{
+      hasCompleted = YES;
+    }];
 
-		[subject sendCompleted];
-		expect(@(hasCompleted)).to(beFalsy());
+    [subject sendCompleted];
+    expect(@(hasCompleted)).to(beFalsy());
 
-		[sampleSubject sendCompleted];
-		expect(@(hasCompleted)).to(beTruthy());
-	});
+    [sampleSubject sendCompleted];
+    expect(@(hasCompleted)).to(beTruthy());
+  });
 
-	qck_it(@"should not complete before the receiver completes", ^{
-		__block BOOL hasCompleted = NO;
-		[sampled subscribeCompleted:^{
-			hasCompleted = YES;
-		}];
+  qck_it(@"should not complete before the receiver completes", ^{
+    __block BOOL hasCompleted = NO;
+    [sampled subscribeCompleted:^{
+      hasCompleted = YES;
+    }];
 
-		[sampleSubject sendCompleted];
-		expect(@(hasCompleted)).to(beFalsy());
+    [sampleSubject sendCompleted];
+    expect(@(hasCompleted)).to(beFalsy());
 
-		[subject sendCompleted];
-		expect(@(hasCompleted)).to(beTruthy());
-	});
+    [subject sendCompleted];
+    expect(@(hasCompleted)).to(beTruthy());
+  });
 });
 
 qck_describe(@"-collect", ^{
-	__block RACSubject *subject;
-	__block RACSignal *collected;
+  __block RACSubject *subject;
+  __block RACSignal *collected;
 
-	__block id value;
-	__block BOOL hasCompleted;
+  __block id value;
+  __block BOOL hasCompleted;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
-		collected = [subject collect];
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
+    collected = [subject collect];
 
-		value = nil;
-		hasCompleted = NO;
+    value = nil;
+    hasCompleted = NO;
 
-		[collected subscribeNext:^(id x) {
-			value = x;
-		} completed:^{
-			hasCompleted = YES;
-		}];
-	});
+    [collected subscribeNext:^(id x) {
+      value = x;
+    } completed:^{
+      hasCompleted = YES;
+    }];
+  });
 
-	qck_it(@"should send a single array when the original signal completes", ^{
-		NSArray *expected = @[ @1, @2, @3 ];
+  qck_it(@"should send a single array when the original signal completes", ^{
+    NSArray *expected = @[ @1, @2, @3 ];
 
-		[subject sendNext:@1];
-		[subject sendNext:@2];
-		[subject sendNext:@3];
-		expect(value).to(beNil());
+    [subject sendNext:@1];
+    [subject sendNext:@2];
+    [subject sendNext:@3];
+    expect(value).to(beNil());
 
-		[subject sendCompleted];
-		expect(value).to(equal(expected));
-		expect(@(hasCompleted)).to(beTruthy());
-	});
+    [subject sendCompleted];
+    expect(value).to(equal(expected));
+    expect(@(hasCompleted)).to(beTruthy());
+  });
 
-	qck_it(@"should add NSNull to an array for nil values", ^{
-		NSArray *expected = @[ NSNull.null, @1, NSNull.null ];
+  qck_it(@"should add NSNull to an array for nil values", ^{
+    NSArray *expected = @[ NSNull.null, @1, NSNull.null ];
 
-		[subject sendNext:nil];
-		[subject sendNext:@1];
-		[subject sendNext:nil];
-		expect(value).to(beNil());
+    [subject sendNext:nil];
+    [subject sendNext:@1];
+    [subject sendNext:nil];
+    expect(value).to(beNil());
 
-		[subject sendCompleted];
-		expect(value).to(equal(expected));
-		expect(@(hasCompleted)).to(beTruthy());
-	});
+    [subject sendCompleted];
+    expect(value).to(equal(expected));
+    expect(@(hasCompleted)).to(beTruthy());
+  });
 });
 
 qck_describe(@"-bufferWithTime:onScheduler:", ^{
-	__block RACTestScheduler *scheduler;
+  __block RACTestScheduler *scheduler;
 
-	__block RACSubject *input;
-	__block RACSignal *bufferedInput;
-	__block RACTuple *latestValue;
+  __block RACSubject *input;
+  __block RACSignal *bufferedInput;
+  __block RACTuple *latestValue;
 
-	qck_beforeEach(^{
-		scheduler = [[RACTestScheduler alloc] init];
+  qck_beforeEach(^{
+    scheduler = [[RACTestScheduler alloc] init];
 
-		input = [RACSubject subject];
-		bufferedInput = [input bufferWithTime:1 onScheduler:scheduler];
-		latestValue = nil;
+    input = [RACSubject subject];
+    bufferedInput = [input bufferWithTime:1 onScheduler:scheduler];
+    latestValue = nil;
 
-		[bufferedInput subscribeNext:^(RACTuple *x) {
-			latestValue = x;
-		}];
-	});
+    [bufferedInput subscribeNext:^(RACTuple *x) {
+      latestValue = x;
+    }];
+  });
 
-	qck_it(@"should buffer nexts", ^{
-		[input sendNext:@1];
-		[input sendNext:@2];
+  qck_it(@"should buffer nexts", ^{
+    [input sendNext:@1];
+    [input sendNext:@2];
 
-		[scheduler stepAll];
-		expect(latestValue).to(equal(RACTuplePack(@1, @2)));
+    [scheduler stepAll];
+    expect(latestValue).to(equal(RACTuplePack(@1, @2)));
 
-		[input sendNext:@3];
-		[input sendNext:@4];
+    [input sendNext:@3];
+    [input sendNext:@4];
 
-		[scheduler stepAll];
-		expect(latestValue).to(equal(RACTuplePack(@3, @4)));
-	});
+    [scheduler stepAll];
+    expect(latestValue).to(equal(RACTuplePack(@3, @4)));
+  });
 
-	qck_it(@"should not perform buffering until a value is sent", ^{
-		[input sendNext:@1];
-		[input sendNext:@2];
-		[scheduler stepAll];
-		expect(latestValue).to(equal(RACTuplePack(@1, @2)));
+  qck_it(@"should not perform buffering until a value is sent", ^{
+    [input sendNext:@1];
+    [input sendNext:@2];
+    [scheduler stepAll];
+    expect(latestValue).to(equal(RACTuplePack(@1, @2)));
 
-		[scheduler stepAll];
-		expect(latestValue).to(equal(RACTuplePack(@1, @2)));
+    [scheduler stepAll];
+    expect(latestValue).to(equal(RACTuplePack(@1, @2)));
 
-		[input sendNext:@3];
-		[input sendNext:@4];
-		[scheduler stepAll];
-		expect(latestValue).to(equal(RACTuplePack(@3, @4)));
-	});
+    [input sendNext:@3];
+    [input sendNext:@4];
+    [scheduler stepAll];
+    expect(latestValue).to(equal(RACTuplePack(@3, @4)));
+  });
 
-	qck_it(@"should flush any buffered nexts upon completion", ^{
-		[input sendNext:@1];
-		[input sendCompleted];
-		[scheduler stepAll];
-		expect(latestValue).to(equal(RACTuplePack(@1)));
-	});
+  qck_it(@"should flush any buffered nexts upon completion", ^{
+    [input sendNext:@1];
+    [input sendCompleted];
+    [scheduler stepAll];
+    expect(latestValue).to(equal(RACTuplePack(@1)));
+  });
 
-	qck_it(@"should support NSNull values", ^{
-		[input sendNext:NSNull.null];
-		[scheduler stepAll];
-		expect(latestValue).to(equal(RACTuplePack(NSNull.null)));
-	});
+  qck_it(@"should support NSNull values", ^{
+    [input sendNext:NSNull.null];
+    [scheduler stepAll];
+    expect(latestValue).to(equal(RACTuplePack(NSNull.null)));
+  });
 
-	qck_it(@"should buffer nil values", ^{
-		[input sendNext:nil];
-		[scheduler stepAll];
-		expect(latestValue).to(equal(RACTuplePack(nil)));
-	});
+  qck_it(@"should buffer nil values", ^{
+    [input sendNext:nil];
+    [scheduler stepAll];
+    expect(latestValue).to(equal(RACTuplePack(nil)));
+  });
 });
 
 qck_describe(@"-concat", ^{
-	__block RACSubject *subject;
+  __block RACSubject *subject;
 
-	__block RACSignal *oneSignal;
-	__block RACSignal *twoSignal;
-	__block RACSignal *threeSignal;
+  __block RACSignal *oneSignal;
+  __block RACSignal *twoSignal;
+  __block RACSignal *threeSignal;
 
-	__block RACSignal *errorSignal;
-	__block RACSignal *completedSignal;
+  __block RACSignal *errorSignal;
+  __block RACSignal *completedSignal;
 
-	qck_beforeEach(^{
-		subject = [RACReplaySubject subject];
+  qck_beforeEach(^{
+    subject = [RACReplaySubject subject];
 
-		oneSignal = [RACSignal return:@1];
-		twoSignal = [RACSignal return:@2];
-		threeSignal = [RACSignal return:@3];
+    oneSignal = [RACSignal return:@1];
+    twoSignal = [RACSignal return:@2];
+    threeSignal = [RACSignal return:@3];
 
-		errorSignal = [RACSignal error:RACSignalTestError];
-		completedSignal = RACSignal.empty;
-	});
+    errorSignal = [RACSignal error:RACSignalTestError];
+    completedSignal = RACSignal.empty;
+  });
 
-	qck_it(@"should concatenate the values of inner signals", ^{
-		[subject sendNext:oneSignal];
-		[subject sendNext:twoSignal];
-		[subject sendNext:completedSignal];
-		[subject sendNext:threeSignal];
+  qck_it(@"should concatenate the values of inner signals", ^{
+    [subject sendNext:oneSignal];
+    [subject sendNext:twoSignal];
+    [subject sendNext:completedSignal];
+    [subject sendNext:threeSignal];
 
-		NSMutableArray *values = [NSMutableArray array];
-		[[subject concat] subscribeNext:^(id x) {
-			[values addObject:x];
-		}];
+    NSMutableArray *values = [NSMutableArray array];
+    [[subject concat] subscribeNext:^(id x) {
+      [values addObject:x];
+    }];
 
-		NSArray *expected = @[ @1, @2, @3 ];
-		expect(values).to(equal(expected));
-	});
+    NSArray *expected = @[ @1, @2, @3 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"should complete only after all signals complete", ^{
-		RACReplaySubject *valuesSubject = [RACReplaySubject subject];
+  qck_it(@"should complete only after all signals complete", ^{
+    RACReplaySubject *valuesSubject = [RACReplaySubject subject];
 
-		[subject sendNext:valuesSubject];
-		[subject sendCompleted];
+    [subject sendNext:valuesSubject];
+    [subject sendCompleted];
 
-		[valuesSubject sendNext:@1];
-		[valuesSubject sendNext:@2];
-		[valuesSubject sendCompleted];
+    [valuesSubject sendNext:@1];
+    [valuesSubject sendNext:@2];
+    [valuesSubject sendCompleted];
 
-		NSArray *expected = @[ @1, @2 ];
-		expect([[subject concat] toArray]).to(equal(expected));
-	});
+    NSArray *expected = @[ @1, @2 ];
+    expect([[subject concat] toArray]).to(equal(expected));
+  });
 
-	qck_it(@"should pass through errors", ^{
-		[subject sendNext:errorSignal];
+  qck_it(@"should pass through errors", ^{
+    [subject sendNext:errorSignal];
 
-		NSError *error = nil;
-		[[subject concat] firstOrDefault:nil success:NULL error:&error];
-		expect(error).to(equal(RACSignalTestError));
-	});
+    NSError *error = nil;
+    [[subject concat] firstOrDefault:nil success:NULL error:&error];
+    expect(error).to(equal(RACSignalTestError));
+  });
 
-	qck_it(@"should concat signals sent later", ^{
-		[subject sendNext:oneSignal];
+  qck_it(@"should concat signals sent later", ^{
+    [subject sendNext:oneSignal];
 
-		NSMutableArray *values = [NSMutableArray array];
-		[[subject concat] subscribeNext:^(id x) {
-			[values addObject:x];
-		}];
+    NSMutableArray *values = [NSMutableArray array];
+    [[subject concat] subscribeNext:^(id x) {
+      [values addObject:x];
+    }];
 
-		NSArray *expected = @[ @1 ];
-		expect(values).to(equal(expected));
+    NSArray *expected = @[ @1 ];
+    expect(values).to(equal(expected));
 
-		[subject sendNext:[twoSignal delay:0]];
+    [subject sendNext:[twoSignal delay:0]];
 
-		expected = @[ @1, @2 ];
-		expect(values).toEventually(equal(expected));
+    expected = @[ @1, @2 ];
+    expect(values).toEventually(equal(expected));
 
-		[subject sendNext:threeSignal];
+    [subject sendNext:threeSignal];
 
-		expected = @[ @1, @2, @3 ];
-		expect(values).to(equal(expected));
-	});
+    expected = @[ @1, @2, @3 ];
+    expect(values).to(equal(expected));
+  });
 
-	qck_it(@"should dispose the current signal", ^{
-		__block BOOL disposed = NO;
-		__block id<RACSubscriber> innerSubscriber = nil;
-		RACSignal *innerSignal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			// Keep the subscriber alive so it doesn't trigger disposal on dealloc
-			innerSubscriber = subscriber;
-			return [RACDisposable disposableWithBlock:^{
-				disposed = YES;
-			}];
-		}];
+  qck_it(@"should dispose the current signal", ^{
+    __block BOOL disposed = NO;
+    __block id<RACSubscriber> innerSubscriber = nil;
+    RACSignal *innerSignal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      // Keep the subscriber alive so it doesn't trigger disposal on dealloc
+      innerSubscriber = subscriber;
+      return [RACDisposable disposableWithBlock:^{
+        disposed = YES;
+      }];
+    }];
 
-		RACDisposable *concatDisposable = [[subject concat] subscribeCompleted:^{}];
+    RACDisposable *concatDisposable = [[subject concat] subscribeCompleted:^{}];
 
-		[subject sendNext:innerSignal];
-		expect(@(disposed)).notTo(beTruthy());
+    [subject sendNext:innerSignal];
+    expect(@(disposed)).notTo(beTruthy());
 
-		[concatDisposable dispose];
-		expect(@(disposed)).to(beTruthy());
-	});
+    [concatDisposable dispose];
+    expect(@(disposed)).to(beTruthy());
+  });
 
-	qck_it(@"should dispose later signals", ^{
-		__block BOOL disposed = NO;
-		__block id<RACSubscriber> laterSubscriber = nil;
-		RACSignal *laterSignal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-			// Keep the subscriber alive so it doesn't trigger disposal on dealloc
-			laterSubscriber = subscriber;
-			return [RACDisposable disposableWithBlock:^{
-				disposed = YES;
-			}];
-		}];
+  qck_it(@"should dispose later signals", ^{
+    __block BOOL disposed = NO;
+    __block id<RACSubscriber> laterSubscriber = nil;
+    RACSignal *laterSignal = [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+      // Keep the subscriber alive so it doesn't trigger disposal on dealloc
+      laterSubscriber = subscriber;
+      return [RACDisposable disposableWithBlock:^{
+        disposed = YES;
+      }];
+    }];
 
-		RACSubject *firstSignal = [RACSubject subject];
-		RACSignal *outerSignal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:firstSignal];
-			[subscriber sendNext:laterSignal];
-			return nil;
-		}];
+    RACSubject *firstSignal = [RACSubject subject];
+    RACSignal *outerSignal = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:firstSignal];
+      [subscriber sendNext:laterSignal];
+      return nil;
+    }];
 
-		RACDisposable *concatDisposable = [[outerSignal concat] subscribeCompleted:^{}];
+    RACDisposable *concatDisposable = [[outerSignal concat] subscribeCompleted:^{}];
 
-		[firstSignal sendCompleted];
-		expect(@(disposed)).notTo(beTruthy());
+    [firstSignal sendCompleted];
+    expect(@(disposed)).notTo(beTruthy());
 
-		[concatDisposable dispose];
-		expect(@(disposed)).to(beTruthy());
-	});
+    [concatDisposable dispose];
+    expect(@(disposed)).to(beTruthy());
+  });
 });
 
 qck_describe(@"-initially:", ^{
-	__block RACSubject *subject;
+  __block RACSubject *subject;
 
-	__block NSUInteger initiallyInvokedCount;
-	__block RACSignal *signal;
+  __block NSUInteger initiallyInvokedCount;
+  __block RACSignal *signal;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
 
-		initiallyInvokedCount = 0;
-		signal = [subject initially:^{
-			++initiallyInvokedCount;
-		}];
-	});
+    initiallyInvokedCount = 0;
+    signal = [subject initially:^{
+      ++initiallyInvokedCount;
+    }];
+  });
 
-	qck_it(@"should not run without a subscription", ^{
-		[subject sendCompleted];
-		expect(@(initiallyInvokedCount)).to(equal(@0));
-	});
+  qck_it(@"should not run without a subscription", ^{
+    [subject sendCompleted];
+    expect(@(initiallyInvokedCount)).to(equal(@0));
+  });
 
-	qck_it(@"should run on subscription", ^{
-		[signal subscribe:[RACSubscriber new]];
-		expect(@(initiallyInvokedCount)).to(equal(@1));
-	});
+  qck_it(@"should run on subscription", ^{
+    [signal subscribe:[RACSubscriber new]];
+    expect(@(initiallyInvokedCount)).to(equal(@1));
+  });
 
-	qck_it(@"should re-run for each subscription", ^{
-		[signal subscribe:[RACSubscriber new]];
-		[signal subscribe:[RACSubscriber new]];
-		expect(@(initiallyInvokedCount)).to(equal(@2));
-	});
+  qck_it(@"should re-run for each subscription", ^{
+    [signal subscribe:[RACSubscriber new]];
+    [signal subscribe:[RACSubscriber new]];
+    expect(@(initiallyInvokedCount)).to(equal(@2));
+  });
 });
 
 qck_describe(@"-finally:", ^{
-	__block RACSubject *subject;
+  __block RACSubject *subject;
 
-	__block BOOL finallyInvoked;
-	__block RACSignal *signal;
+  __block BOOL finallyInvoked;
+  __block RACSignal *signal;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
 
-		finallyInvoked = NO;
-		signal = [subject finally:^{
-			finallyInvoked = YES;
-		}];
-	});
+    finallyInvoked = NO;
+    signal = [subject finally:^{
+      finallyInvoked = YES;
+    }];
+  });
 
-	qck_it(@"should not run finally without a subscription", ^{
-		[subject sendCompleted];
-		expect(@(finallyInvoked)).to(beFalsy());
-	});
+  qck_it(@"should not run finally without a subscription", ^{
+    [subject sendCompleted];
+    expect(@(finallyInvoked)).to(beFalsy());
+  });
 
-	qck_describe(@"with a subscription", ^{
-		__block RACDisposable *disposable;
+  qck_describe(@"with a subscription", ^{
+    __block RACDisposable *disposable;
 
-		qck_beforeEach(^{
-			disposable = [signal subscribeCompleted:^{}];
-		});
+    qck_beforeEach(^{
+      disposable = [signal subscribeCompleted:^{}];
+    });
 
-		qck_afterEach(^{
-			[disposable dispose];
-		});
+    qck_afterEach(^{
+      [disposable dispose];
+    });
 
-		qck_it(@"should not run finally upon next", ^{
-			[subject sendNext:RACUnit.defaultUnit];
-			expect(@(finallyInvoked)).to(beFalsy());
-		});
+    qck_it(@"should not run finally upon next", ^{
+      [subject sendNext:RACUnit.defaultUnit];
+      expect(@(finallyInvoked)).to(beFalsy());
+    });
 
-		qck_it(@"should run finally upon completed", ^{
-			[subject sendCompleted];
-			expect(@(finallyInvoked)).to(beTruthy());
-		});
+    qck_it(@"should run finally upon completed", ^{
+      [subject sendCompleted];
+      expect(@(finallyInvoked)).to(beTruthy());
+    });
 
-		qck_it(@"should run finally upon error", ^{
-			[subject sendError:nil];
-			expect(@(finallyInvoked)).to(beTruthy());
-		});
-	});
+    qck_it(@"should run finally upon error", ^{
+      [subject sendError:nil];
+      expect(@(finallyInvoked)).to(beTruthy());
+    });
+  });
 });
 
 qck_describe(@"-ignoreValues", ^{
-	__block RACSubject *subject;
+  __block RACSubject *subject;
 
-	__block BOOL gotNext;
-	__block BOOL gotCompleted;
-	__block NSError *receivedError;
+  __block BOOL gotNext;
+  __block BOOL gotCompleted;
+  __block NSError *receivedError;
 
-	qck_beforeEach(^{
-		subject = [RACSubject subject];
+  qck_beforeEach(^{
+    subject = [RACSubject subject];
 
-		gotNext = NO;
-		gotCompleted = NO;
-		receivedError = nil;
+    gotNext = NO;
+    gotCompleted = NO;
+    receivedError = nil;
 
-		[[subject ignoreValues] subscribeNext:^(id _) {
-			gotNext = YES;
-		} error:^(NSError *error) {
-			receivedError = error;
-		} completed:^{
-			gotCompleted = YES;
-		}];
-	});
+    [[subject ignoreValues] subscribeNext:^(id _) {
+      gotNext = YES;
+    } error:^(NSError *error) {
+      receivedError = error;
+    } completed:^{
+      gotCompleted = YES;
+    }];
+  });
 
-	qck_it(@"should skip nexts and pass through completed", ^{
-		[subject sendNext:RACUnit.defaultUnit];
-		[subject sendCompleted];
+  qck_it(@"should skip nexts and pass through completed", ^{
+    [subject sendNext:RACUnit.defaultUnit];
+    [subject sendCompleted];
 
-		expect(@(gotNext)).to(beFalsy());
-		expect(@(gotCompleted)).to(beTruthy());
-		expect(receivedError).to(beNil());
-	});
+    expect(@(gotNext)).to(beFalsy());
+    expect(@(gotCompleted)).to(beTruthy());
+    expect(receivedError).to(beNil());
+  });
 
-	qck_it(@"should skip nexts and pass through errors", ^{
-		[subject sendNext:RACUnit.defaultUnit];
-		[subject sendError:RACSignalTestError];
+  qck_it(@"should skip nexts and pass through errors", ^{
+    [subject sendNext:RACUnit.defaultUnit];
+    [subject sendError:RACSignalTestError];
 
-		expect(@(gotNext)).to(beFalsy());
-		expect(@(gotCompleted)).to(beFalsy());
-		expect(receivedError).to(equal(RACSignalTestError));
-	});
+    expect(@(gotNext)).to(beFalsy());
+    expect(@(gotCompleted)).to(beFalsy());
+    expect(receivedError).to(equal(RACSignalTestError));
+  });
 });
 
 qck_describe(@"-materialize", ^{
-	qck_it(@"should convert nexts and completed into RACEvents", ^{
-		NSArray *events = [[[RACSignal return:RACUnit.defaultUnit] materialize] toArray];
-		NSArray *expected = @[
-			[RACEvent eventWithValue:RACUnit.defaultUnit],
-			RACEvent.completedEvent
-		];
+  qck_it(@"should convert nexts and completed into RACEvents", ^{
+    NSArray *events = [[[RACSignal return:RACUnit.defaultUnit] materialize] toArray];
+    NSArray *expected = @[
+      [RACEvent eventWithValue:RACUnit.defaultUnit],
+      RACEvent.completedEvent
+    ];
 
-		expect(events).to(equal(expected));
-	});
+    expect(events).to(equal(expected));
+  });
 
-	qck_it(@"should convert errors into RACEvents and complete", ^{
-		NSArray *events = [[[RACSignal error:RACSignalTestError] materialize] toArray];
-		NSArray *expected = @[ [RACEvent eventWithError:RACSignalTestError] ];
-		expect(events).to(equal(expected));
-	});
+  qck_it(@"should convert errors into RACEvents and complete", ^{
+    NSArray *events = [[[RACSignal error:RACSignalTestError] materialize] toArray];
+    NSArray *expected = @[ [RACEvent eventWithError:RACSignalTestError] ];
+    expect(events).to(equal(expected));
+  });
 });
 
 qck_describe(@"-dematerialize", ^{
-	qck_it(@"should convert nexts from RACEvents", ^{
-		RACSignal *events = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:[RACEvent eventWithValue:@1]];
-			[subscriber sendNext:[RACEvent eventWithValue:@2]];
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should convert nexts from RACEvents", ^{
+    RACSignal *events = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:[RACEvent eventWithValue:@1]];
+      [subscriber sendNext:[RACEvent eventWithValue:@2]];
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		NSArray *expected = @[ @1, @2 ];
-		expect([[events dematerialize] toArray]).to(equal(expected));
-	});
+    NSArray *expected = @[ @1, @2 ];
+    expect([[events dematerialize] toArray]).to(equal(expected));
+  });
 
-	qck_it(@"should convert completed from a RACEvent", ^{
-		RACSignal *events = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:[RACEvent eventWithValue:@1]];
-			[subscriber sendNext:RACEvent.completedEvent];
-			[subscriber sendNext:[RACEvent eventWithValue:@2]];
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should convert completed from a RACEvent", ^{
+    RACSignal *events = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:[RACEvent eventWithValue:@1]];
+      [subscriber sendNext:RACEvent.completedEvent];
+      [subscriber sendNext:[RACEvent eventWithValue:@2]];
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		NSArray *expected = @[ @1 ];
-		expect([[events dematerialize] toArray]).to(equal(expected));
-	});
+    NSArray *expected = @[ @1 ];
+    expect([[events dematerialize] toArray]).to(equal(expected));
+  });
 
-	qck_it(@"should convert error from a RACEvent", ^{
-		RACSignal *events = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
-			[subscriber sendNext:[RACEvent eventWithError:RACSignalTestError]];
-			[subscriber sendNext:[RACEvent eventWithValue:@1]];
-			[subscriber sendCompleted];
-			return nil;
-		}];
+  qck_it(@"should convert error from a RACEvent", ^{
+    RACSignal *events = [RACSignal createSignal:^ id (id<RACSubscriber> subscriber) {
+      [subscriber sendNext:[RACEvent eventWithError:RACSignalTestError]];
+      [subscriber sendNext:[RACEvent eventWithValue:@1]];
+      [subscriber sendCompleted];
+      return nil;
+    }];
 
-		__block NSError *error = nil;
-		expect([[events dematerialize] firstOrDefault:nil success:NULL error:&error]).to(beNil());
-		expect(error).to(equal(RACSignalTestError));
-	});
+    __block NSError *error = nil;
+    expect([[events dematerialize] firstOrDefault:nil success:NULL error:&error]).to(beNil());
+    expect(error).to(equal(RACSignalTestError));
+  });
 });
 
 qck_describe(@"-not", ^{
-	qck_it(@"should invert every BOOL sent", ^{
-		RACSubject *subject = [RACReplaySubject subject];
-		[subject sendNext:@NO];
-		[subject sendNext:@YES];
-		[subject sendCompleted];
-		NSArray *results = [[subject not] toArray];
-		NSArray *expected = @[ @YES, @NO ];
-		expect(results).to(equal(expected));
-	});
+  qck_it(@"should invert every BOOL sent", ^{
+    RACSubject *subject = [RACReplaySubject subject];
+    [subject sendNext:@NO];
+    [subject sendNext:@YES];
+    [subject sendCompleted];
+    NSArray *results = [[subject not] toArray];
+    NSArray *expected = @[ @YES, @NO ];
+    expect(results).to(equal(expected));
+  });
 });
 
 qck_describe(@"-and", ^{
-	qck_it(@"should return YES if all YES values are sent", ^{
-		RACSubject *subject = [RACReplaySubject subject];
+  qck_it(@"should return YES if all YES values are sent", ^{
+    RACSubject *subject = [RACReplaySubject subject];
 
-		[subject sendNext:RACTuplePack(@YES, @NO, @YES)];
-		[subject sendNext:RACTuplePack(@NO, @NO, @NO)];
-		[subject sendNext:RACTuplePack(@YES, @YES, @YES)];
-		[subject sendCompleted];
+    [subject sendNext:RACTuplePack(@YES, @NO, @YES)];
+    [subject sendNext:RACTuplePack(@NO, @NO, @NO)];
+    [subject sendNext:RACTuplePack(@YES, @YES, @YES)];
+    [subject sendCompleted];
 
-		NSArray *results = [[subject and] toArray];
-		NSArray *expected = @[ @NO, @NO, @YES ];
+    NSArray *results = [[subject and] toArray];
+    NSArray *expected = @[ @NO, @NO, @YES ];
 
-		expect(results).to(equal(expected));
-	});
+    expect(results).to(equal(expected));
+  });
 });
 
 qck_describe(@"-or", ^{
-	qck_it(@"should return YES for any YES values sent", ^{
-		RACSubject *subject = [RACReplaySubject subject];
+  qck_it(@"should return YES for any YES values sent", ^{
+    RACSubject *subject = [RACReplaySubject subject];
 
-		[subject sendNext:RACTuplePack(@YES, @NO, @YES)];
-		[subject sendNext:RACTuplePack(@NO, @NO, @NO)];
-		[subject sendCompleted];
+    [subject sendNext:RACTuplePack(@YES, @NO, @YES)];
+    [subject sendNext:RACTuplePack(@NO, @NO, @NO)];
+    [subject sendCompleted];
 
-		NSArray *results = [[subject or] toArray];
-		NSArray *expected = @[ @YES, @NO ];
+    NSArray *results = [[subject or] toArray];
+    NSArray *expected = @[ @YES, @NO ];
 
-		expect(results).to(equal(expected));
-	});
+    expect(results).to(equal(expected));
+  });
 });
 
 qck_describe(@"-groupBy:", ^{
-	qck_it(@"should send completed to all grouped signals.", ^{
-		RACSubject *subject = [RACReplaySubject subject];
+  qck_it(@"should send completed to all grouped signals.", ^{
+    RACSubject *subject = [RACReplaySubject subject];
 
-		__block NSUInteger groupedSignalCount = 0;
-		__block NSUInteger completedGroupedSignalCount = 0;
-		[[subject groupBy:^(NSNumber *number) {
-			return @(floorf(number.floatValue));
-		}] subscribeNext:^(RACGroupedSignal *groupedSignal) {
-			++groupedSignalCount;
+    __block NSUInteger groupedSignalCount = 0;
+    __block NSUInteger completedGroupedSignalCount = 0;
+    [[subject groupBy:^(NSNumber *number) {
+      return @(floorf(number.floatValue));
+    }] subscribeNext:^(RACGroupedSignal *groupedSignal) {
+      ++groupedSignalCount;
 
-			[groupedSignal subscribeCompleted:^{
-				++completedGroupedSignalCount;
-			}];
-		}];
+      [groupedSignal subscribeCompleted:^{
+        ++completedGroupedSignalCount;
+      }];
+    }];
 
-		[subject sendNext:@1];
-		[subject sendNext:@2];
-		[subject sendCompleted];
+    [subject sendNext:@1];
+    [subject sendNext:@2];
+    [subject sendCompleted];
 
-		expect(@(completedGroupedSignalCount)).to(equal(@(groupedSignalCount)));
-	});
+    expect(@(completedGroupedSignalCount)).to(equal(@(groupedSignalCount)));
+  });
 
-	qck_it(@"should send error to all grouped signals.", ^{
-		RACSubject *subject = [RACReplaySubject subject];
+  qck_it(@"should send error to all grouped signals.", ^{
+    RACSubject *subject = [RACReplaySubject subject];
 
-		__block NSUInteger groupedSignalCount = 0;
-		__block NSUInteger erroneousGroupedSignalCount = 0;
-		[[subject groupBy:^(NSNumber *number) {
-			return @(floorf(number.floatValue));
-		}] subscribeNext:^(RACGroupedSignal *groupedSignal) {
-			++groupedSignalCount;
+    __block NSUInteger groupedSignalCount = 0;
+    __block NSUInteger erroneousGroupedSignalCount = 0;
+    [[subject groupBy:^(NSNumber *number) {
+      return @(floorf(number.floatValue));
+    }] subscribeNext:^(RACGroupedSignal *groupedSignal) {
+      ++groupedSignalCount;
 
-			[groupedSignal subscribeError:^(NSError *error) {
-				++erroneousGroupedSignalCount;
+      [groupedSignal subscribeError:^(NSError *error) {
+        ++erroneousGroupedSignalCount;
 
-				expect(error.domain).to(equal(@"TestDomain"));
-				expect(@(error.code)).to(equal(@123));
-			}];
-		}];
+        expect(error.domain).to(equal(@"TestDomain"));
+        expect(@(error.code)).to(equal(@123));
+      }];
+    }];
 
-		[subject sendNext:@1];
-		[subject sendNext:@2];
-		[subject sendError:[NSError errorWithDomain:@"TestDomain" code:123 userInfo:nil]];
+    [subject sendNext:@1];
+    [subject sendNext:@2];
+    [subject sendError:[NSError errorWithDomain:@"TestDomain" code:123 userInfo:nil]];
 
-		expect(@(erroneousGroupedSignalCount)).to(equal(@(groupedSignalCount)));
-	});
+    expect(@(erroneousGroupedSignalCount)).to(equal(@(groupedSignalCount)));
+  });
 
 
-	qck_it(@"should send completed in the order grouped signals were created.", ^{
-		RACSubject *subject = [RACReplaySubject subject];
+  qck_it(@"should send completed in the order grouped signals were created.", ^{
+    RACSubject *subject = [RACReplaySubject subject];
 
-		NSMutableArray *startedSignals = [NSMutableArray array];
-		NSMutableArray *completedSignals = [NSMutableArray array];
-		[[subject groupBy:^(NSNumber *number) {
-			return @(number.integerValue % 4);
-		}] subscribeNext:^(RACGroupedSignal *groupedSignal) {
-			[startedSignals addObject:groupedSignal];
+    NSMutableArray *startedSignals = [NSMutableArray array];
+    NSMutableArray *completedSignals = [NSMutableArray array];
+    [[subject groupBy:^(NSNumber *number) {
+      return @(number.integerValue % 4);
+    }] subscribeNext:^(RACGroupedSignal *groupedSignal) {
+      [startedSignals addObject:groupedSignal];
 
-			[groupedSignal subscribeCompleted:^{
-				[completedSignals addObject:groupedSignal];
-			}];
-		}];
+      [groupedSignal subscribeCompleted:^{
+        [completedSignals addObject:groupedSignal];
+      }];
+    }];
 
-		for (NSInteger i = 0; i < 20; i++)
-		{
-			[subject sendNext:@(i)];
-		}
-		[subject sendCompleted];
+    for (NSInteger i = 0; i < 20; i++)
+    {
+      [subject sendNext:@(i)];
+    }
+    [subject sendCompleted];
 
-		expect(completedSignals).to(equal(startedSignals));
-	});
+    expect(completedSignals).to(equal(startedSignals));
+  });
 });
 
 qck_describe(@"starting signals", ^{
-	qck_describe(@"+startLazilyWithScheduler:block:", ^{
-		__block NSUInteger invokedCount = 0;
-		__block void (^subscribe)(void);
+  qck_describe(@"+startLazilyWithScheduler:block:", ^{
+    __block NSUInteger invokedCount = 0;
+    __block void (^subscribe)(void);
 
-		qck_beforeEach(^{
-			invokedCount = 0;
+    qck_beforeEach(^{
+      invokedCount = 0;
 
-			RACSignal *signal = [RACSignal startLazilyWithScheduler:RACScheduler.immediateScheduler block:^(id<RACSubscriber> subscriber) {
-				invokedCount++;
-				[subscriber sendNext:@42];
-				[subscriber sendCompleted];
-			}];
+      RACSignal *signal = [RACSignal startLazilyWithScheduler:RACScheduler.immediateScheduler block:^(id<RACSubscriber> subscriber) {
+        invokedCount++;
+        [subscriber sendNext:@42];
+        [subscriber sendCompleted];
+      }];
 
-			subscribe = [^{
-				[signal subscribe:[RACSubscriber subscriberWithNext:nil error:nil completed:nil]];
-			} copy];
-		});
+      subscribe = [^{
+        [signal subscribe:[RACSubscriber subscriberWithNext:nil error:nil completed:nil]];
+      } copy];
+    });
 
-		qck_it(@"should only invoke the block on subscription", ^{
-			expect(@(invokedCount)).to(equal(@0));
-			subscribe();
-			expect(@(invokedCount)).to(equal(@1));
-		});
+    qck_it(@"should only invoke the block on subscription", ^{
+      expect(@(invokedCount)).to(equal(@0));
+      subscribe();
+      expect(@(invokedCount)).to(equal(@1));
+    });
 
-		qck_it(@"should only invoke the block once", ^{
-			expect(@(invokedCount)).to(equal(@0));
-			subscribe();
-			expect(@(invokedCount)).to(equal(@1));
-			subscribe();
-			expect(@(invokedCount)).to(equal(@1));
-			subscribe();
-			expect(@(invokedCount)).to(equal(@1));
-		});
+    qck_it(@"should only invoke the block once", ^{
+      expect(@(invokedCount)).to(equal(@0));
+      subscribe();
+      expect(@(invokedCount)).to(equal(@1));
+      subscribe();
+      expect(@(invokedCount)).to(equal(@1));
+      subscribe();
+      expect(@(invokedCount)).to(equal(@1));
+    });
 
-		qck_it(@"should invoke the block on the given scheduler", ^{
-			RACScheduler *scheduler = [RACScheduler scheduler];
-			__block RACScheduler *currentScheduler;
-			[[[RACSignal
-				startLazilyWithScheduler:scheduler block:^(id<RACSubscriber> subscriber) {
-					currentScheduler = RACScheduler.currentScheduler;
-				}]
-				publish]
-				connect];
+    qck_it(@"should invoke the block on the given scheduler", ^{
+      RACScheduler *scheduler = [RACScheduler scheduler];
+      __block RACScheduler *currentScheduler;
+      [[[RACSignal
+        startLazilyWithScheduler:scheduler block:^(id<RACSubscriber> subscriber) {
+          currentScheduler = RACScheduler.currentScheduler;
+        }]
+        publish]
+        connect];
 
-			expect(currentScheduler).toEventually(equal(scheduler));
-		});
-	});
+      expect(currentScheduler).toEventually(equal(scheduler));
+    });
+  });
 
-	qck_describe(@"+startEagerlyWithScheduler:block:", ^{
-		qck_it(@"should immediately invoke the block", ^{
-			__block BOOL blockInvoked = NO;
-			[RACSignal startEagerlyWithScheduler:[RACScheduler scheduler] block:^(id<RACSubscriber> subscriber) {
-				blockInvoked = YES;
-			}];
+  qck_describe(@"+startEagerlyWithScheduler:block:", ^{
+    qck_it(@"should immediately invoke the block", ^{
+      __block BOOL blockInvoked = NO;
+      [RACSignal startEagerlyWithScheduler:[RACScheduler scheduler] block:^(id<RACSubscriber> subscriber) {
+        blockInvoked = YES;
+      }];
 
-			expect(@(blockInvoked)).toEventually(beTruthy());
-		});
+      expect(@(blockInvoked)).toEventually(beTruthy());
+    });
 
-		qck_it(@"should only invoke the block once", ^{
-			__block NSUInteger invokedCount = 0;
-			RACSignal *signal = [RACSignal startEagerlyWithScheduler:RACScheduler.immediateScheduler block:^(id<RACSubscriber> subscriber) {
-				invokedCount++;
-			}];
+    qck_it(@"should only invoke the block once", ^{
+      __block NSUInteger invokedCount = 0;
+      RACSignal *signal = [RACSignal startEagerlyWithScheduler:RACScheduler.immediateScheduler block:^(id<RACSubscriber> subscriber) {
+        invokedCount++;
+      }];
 
-			expect(@(invokedCount)).to(equal(@1));
+      expect(@(invokedCount)).to(equal(@1));
 
-			[[signal publish] connect];
-			expect(@(invokedCount)).to(equal(@1));
+      [[signal publish] connect];
+      expect(@(invokedCount)).to(equal(@1));
 
-			[[signal publish] connect];
-			expect(@(invokedCount)).to(equal(@1));
-		});
+      [[signal publish] connect];
+      expect(@(invokedCount)).to(equal(@1));
+    });
 
-		qck_it(@"should invoke the block on the given scheduler", ^{
-			RACScheduler *scheduler = [RACScheduler scheduler];
-			__block RACScheduler *currentScheduler;
-			[RACSignal startEagerlyWithScheduler:scheduler block:^(id<RACSubscriber> subscriber) {
-				currentScheduler = RACScheduler.currentScheduler;
-			}];
+    qck_it(@"should invoke the block on the given scheduler", ^{
+      RACScheduler *scheduler = [RACScheduler scheduler];
+      __block RACScheduler *currentScheduler;
+      [RACSignal startEagerlyWithScheduler:scheduler block:^(id<RACSubscriber> subscriber) {
+        currentScheduler = RACScheduler.currentScheduler;
+      }];
 
-			expect(currentScheduler).toEventually(equal(scheduler));
-		});
-	});
+      expect(currentScheduler).toEventually(equal(scheduler));
+    });
+  });
 });
 
 qck_describe(@"-toArray", ^{
-	__block RACSubject *subject;
+  __block RACSubject *subject;
 
-	qck_beforeEach(^{
-		subject = [RACReplaySubject subject];
-	});
+  qck_beforeEach(^{
+    subject = [RACReplaySubject subject];
+  });
 
-	qck_it(@"should return an array which contains NSNulls for nil values", ^{
-		NSArray *expected = @[ NSNull.null, @1, NSNull.null ];
+  qck_it(@"should return an array which contains NSNulls for nil values", ^{
+    NSArray *expected = @[ NSNull.null, @1, NSNull.null ];
 
-		[subject sendNext:nil];
-		[subject sendNext:@1];
-		[subject sendNext:nil];
-		[subject sendCompleted];
+    [subject sendNext:nil];
+    [subject sendNext:@1];
+    [subject sendNext:nil];
+    [subject sendCompleted];
 
-		expect([subject toArray]).to(equal(expected));
-	});
+    expect([subject toArray]).to(equal(expected));
+  });
 
-	qck_it(@"should return nil upon error", ^{
-		[subject sendError:nil];
-		expect([subject toArray]).to(beNil());
-	});
+  qck_it(@"should return nil upon error", ^{
+    [subject sendError:nil];
+    expect([subject toArray]).to(beNil());
+  });
 
-	qck_it(@"should return nil upon error even if some nexts were sent", ^{
-		[subject sendNext:@1];
-		[subject sendNext:@2];
-		[subject sendError:nil];
+  qck_it(@"should return nil upon error even if some nexts were sent", ^{
+    [subject sendNext:@1];
+    [subject sendNext:@2];
+    [subject sendError:nil];
 
-		expect([subject toArray]).to(beNil());
-	});
+    expect([subject toArray]).to(beNil());
+  });
 });
 
 qck_describe(@"-ignore:", ^{
-	qck_it(@"should ignore nil", ^{
-		RACSignal *signal = [[RACSignal
-			createSignal:^ id (id<RACSubscriber> subscriber) {
-				[subscriber sendNext:@1];
-				[subscriber sendNext:nil];
-				[subscriber sendNext:@3];
-				[subscriber sendNext:@4];
-				[subscriber sendNext:nil];
-				[subscriber sendCompleted];
-				return nil;
-			}]
-			ignore:nil];
+  qck_it(@"should ignore nil", ^{
+    RACSignal *signal = [[RACSignal
+      createSignal:^ id (id<RACSubscriber> subscriber) {
+        [subscriber sendNext:@1];
+        [subscriber sendNext:nil];
+        [subscriber sendNext:@3];
+        [subscriber sendNext:@4];
+        [subscriber sendNext:nil];
+        [subscriber sendCompleted];
+        return nil;
+      }]
+      ignore:nil];
 
-		NSArray *expected = @[ @1, @3, @4 ];
-		expect([signal toArray]).to(equal(expected));
-	});
+    NSArray *expected = @[ @1, @3, @4 ];
+    expect([signal toArray]).to(equal(expected));
+  });
 });
 
 qck_describe(@"-replayLazily", ^{
-	__block NSUInteger subscriptionCount;
-	__block BOOL disposed;
+  __block NSUInteger subscriptionCount;
+  __block BOOL disposed;
 
-	__block RACSignal *signal;
-	__block RACSubject *disposeSubject;
-	__block RACSignal *replayedSignal;
+  __block RACSignal *signal;
+  __block RACSubject *disposeSubject;
+  __block RACSignal *replayedSignal;
 
-	qck_beforeEach(^{
-		subscriptionCount = 0;
-		disposed = NO;
+  qck_beforeEach(^{
+    subscriptionCount = 0;
+    disposed = NO;
 
-		signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-			subscriptionCount++;
-			[subscriber sendNext:RACUnit.defaultUnit];
+    signal = [RACSignal createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
+      subscriptionCount++;
+      [subscriber sendNext:RACUnit.defaultUnit];
 
-			RACDisposable *schedulingDisposable = [RACScheduler.mainThreadScheduler schedule:^{
-				[subscriber sendNext:RACUnit.defaultUnit];
-				[subscriber sendCompleted];
-			}];
+      RACDisposable *schedulingDisposable = [RACScheduler.mainThreadScheduler schedule:^{
+        [subscriber sendNext:RACUnit.defaultUnit];
+        [subscriber sendCompleted];
+      }];
 
-			return [RACDisposable disposableWithBlock:^{
-				[schedulingDisposable dispose];
-				disposed = YES;
-			}];
-		}];
+      return [RACDisposable disposableWithBlock:^{
+        [schedulingDisposable dispose];
+        disposed = YES;
+      }];
+    }];
 
-		disposeSubject = [RACSubject subject];
-		replayedSignal = [[signal takeUntil:disposeSubject] replayLazily];
-	});
+    disposeSubject = [RACSubject subject];
+    replayedSignal = [[signal takeUntil:disposeSubject] replayLazily];
+  });
 
-	qck_it(@"should forward the input signal upon subscription", ^{
-		expect(@(subscriptionCount)).to(equal(@0));
+  qck_it(@"should forward the input signal upon subscription", ^{
+    expect(@(subscriptionCount)).to(equal(@0));
 
-		expect(@([replayedSignal asynchronouslyWaitUntilCompleted:NULL])).to(beTruthy());
-		expect(@(subscriptionCount)).to(equal(@1));
-	});
+    expect(@([replayedSignal asynchronouslyWaitUntilCompleted:NULL])).to(beTruthy());
+    expect(@(subscriptionCount)).to(equal(@1));
+  });
 
-	qck_it(@"should replay the input signal for future subscriptions", ^{
-		NSArray *events = [[[replayedSignal materialize] collect] asynchronousFirstOrDefault:nil success:NULL error:NULL];
-		expect(events).notTo(beNil());
+  qck_it(@"should replay the input signal for future subscriptions", ^{
+    NSArray *events = [[[replayedSignal materialize] collect] asynchronousFirstOrDefault:nil success:NULL error:NULL];
+    expect(events).notTo(beNil());
 
-		expect([[[replayedSignal materialize] collect] asynchronousFirstOrDefault:nil success:NULL error:NULL]).to(equal(events));
-		expect(@(subscriptionCount)).to(equal(@1));
-	});
+    expect([[[replayedSignal materialize] collect] asynchronousFirstOrDefault:nil success:NULL error:NULL]).to(equal(events));
+    expect(@(subscriptionCount)).to(equal(@1));
+  });
 
-	qck_it(@"should replay even after disposal", ^{
-		__block NSUInteger valueCount = 0;
-		[replayedSignal subscribeNext:^(id x) {
-			valueCount++;
-		}];
+  qck_it(@"should replay even after disposal", ^{
+    __block NSUInteger valueCount = 0;
+    [replayedSignal subscribeNext:^(id x) {
+      valueCount++;
+    }];
 
-		[disposeSubject sendCompleted];
-		expect(@(valueCount)).to(equal(@1));
-		expect(@([[replayedSignal toArray] count])).to(equal(@(valueCount)));
-	});
+    [disposeSubject sendCompleted];
+    expect(@(valueCount)).to(equal(@1));
+    expect(@([[replayedSignal toArray] count])).to(equal(@(valueCount)));
+  });
 });
 
 qck_describe(@"-reduceApply", ^{
-	qck_it(@"should apply a block to the rest of a tuple", ^{
-		RACSubject *subject = [RACReplaySubject subject];
+  qck_it(@"should apply a block to the rest of a tuple", ^{
+    RACSubject *subject = [RACReplaySubject subject];
 
-		id sum = ^(NSNumber *a, NSNumber *b) {
-			return @(a.intValue + b.intValue);
-		};
-		id madd = ^(NSNumber *a, NSNumber *b, NSNumber *c) {
-			return @(a.intValue * b.intValue + c.intValue);
-		};
+    id sum = ^(NSNumber *a, NSNumber *b) {
+      return @(a.intValue + b.intValue);
+    };
+    id madd = ^(NSNumber *a, NSNumber *b, NSNumber *c) {
+      return @(a.intValue * b.intValue + c.intValue);
+    };
 
-		[subject sendNext:RACTuplePack(sum, @1, @2)];
-		[subject sendNext:RACTuplePack(madd, @2, @3, @1)];
-		[subject sendCompleted];
+    [subject sendNext:RACTuplePack(sum, @1, @2)];
+    [subject sendNext:RACTuplePack(madd, @2, @3, @1)];
+    [subject sendCompleted];
 
-		NSArray *results = [[subject reduceApply] toArray];
-		NSArray *expected = @[ @3, @7 ];
+    NSArray *results = [[subject reduceApply] toArray];
+    NSArray *expected = @[ @3, @7 ];
 
-		expect(results).to(equal(expected));
-	});
+    expect(results).to(equal(expected));
+  });
 });
 
 describe(@"-deliverOnMainThread", ^{
-	void (^dispatchSyncInBackground)(dispatch_block_t) = ^(dispatch_block_t block) {
-		dispatch_group_t group = dispatch_group_create();
-		dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), block);
-		dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
-	};
+  void (^dispatchSyncInBackground)(dispatch_block_t) = ^(dispatch_block_t block) {
+    dispatch_group_t group = dispatch_group_create();
+    dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), block);
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+  };
 
-	beforeEach(^{
-		expect(@(NSThread.isMainThread)).to(beTruthy());
-	});
+  beforeEach(^{
+    expect(@(NSThread.isMainThread)).to(beTruthy());
+  });
 
-	it(@"should deliver events immediately when on the main thread", ^{
-		RACSubject *subject = [RACSubject subject];
-		NSMutableArray *values = [NSMutableArray array];
+  it(@"should deliver events immediately when on the main thread", ^{
+    RACSubject *subject = [RACSubject subject];
+    NSMutableArray *values = [NSMutableArray array];
 
-		[[subject deliverOnMainThread] subscribeNext:^(id value) {
-			[values addObject:value];
-		}];
+    [[subject deliverOnMainThread] subscribeNext:^(id value) {
+      [values addObject:value];
+    }];
 
-		[subject sendNext:@0];
-		expect(values).to(equal(@[ @0 ]));
+    [subject sendNext:@0];
+    expect(values).to(equal(@[ @0 ]));
 
-		[subject sendNext:@1];
-		[subject sendNext:@2];
-		expect(values).to(equal(@[ @0, @1, @2 ]));
-	});
+    [subject sendNext:@1];
+    [subject sendNext:@2];
+    expect(values).to(equal(@[ @0, @1, @2 ]));
+  });
 
-	it(@"should enqueue events sent from the background", ^{
-		RACSubject *subject = [RACSubject subject];
-		NSMutableArray *values = [NSMutableArray array];
+  it(@"should enqueue events sent from the background", ^{
+    RACSubject *subject = [RACSubject subject];
+    NSMutableArray *values = [NSMutableArray array];
 
-		[[subject deliverOnMainThread] subscribeNext:^(id value) {
-			[values addObject:value];
-		}];
+    [[subject deliverOnMainThread] subscribeNext:^(id value) {
+      [values addObject:value];
+    }];
 
-		dispatchSyncInBackground(^{
-			[subject sendNext:@0];
-		});
+    dispatchSyncInBackground(^{
+      [subject sendNext:@0];
+    });
 
-		expect(values).to(equal(@[]));
-		expect(values).toEventually(equal(@[ @0 ]));
+    expect(values).to(equal(@[]));
+    expect(values).toEventually(equal(@[ @0 ]));
 
-		dispatchSyncInBackground(^{
-			[subject sendNext:@1];
-			[subject sendNext:@2];
-		});
+    dispatchSyncInBackground(^{
+      [subject sendNext:@1];
+      [subject sendNext:@2];
+    });
 
-		expect(values).to(equal(@[ @0 ]));
-		expect(values).toEventually(equal(@[ @0, @1, @2 ]));
-	});
+    expect(values).to(equal(@[ @0 ]));
+    expect(values).toEventually(equal(@[ @0, @1, @2 ]));
+  });
 
-	it(@"should enqueue events sent from the main thread after events from the background", ^{
-		RACSubject *subject = [RACSubject subject];
-		NSMutableArray *values = [NSMutableArray array];
+  it(@"should enqueue events sent from the main thread after events from the background", ^{
+    RACSubject *subject = [RACSubject subject];
+    NSMutableArray *values = [NSMutableArray array];
 
-		[[subject deliverOnMainThread] subscribeNext:^(id value) {
-			[values addObject:value];
-		}];
+    [[subject deliverOnMainThread] subscribeNext:^(id value) {
+      [values addObject:value];
+    }];
 
-		dispatchSyncInBackground(^{
-			[subject sendNext:@0];
-		});
+    dispatchSyncInBackground(^{
+      [subject sendNext:@0];
+    });
 
-		[subject sendNext:@1];
-		[subject sendNext:@2];
+    [subject sendNext:@1];
+    [subject sendNext:@2];
 
-		expect(values).to(equal(@[]));
-		expect(values).toEventually(equal(@[ @0, @1, @2 ]));
-	});
+    expect(values).to(equal(@[]));
+    expect(values).toEventually(equal(@[ @0, @1, @2 ]));
+  });
 });
 
 QuickSpecEnd


### PR DESCRIPTION
@barakyoresh there are two commits that convert tabs to spaces. I wonder if we should do this to the entire project.

The only operator that needs extra care is `-flattenMap:`. @alexger - would like your input on the atomic operations there (they are without barriers - I've took the implementation from an old PR to RAC's repo).

The atomic operations will be replaced with non-deprecated versions in a future PR.