### PR TITLE
extobjc: Remove header guards.

### DIFF
--- a/ReactiveObjC/extobjc/EXTKeyPathCoding.h
+++ b/ReactiveObjC/extobjc/EXTKeyPathCoding.h
@@ -7,9 +7,6 @@
 //  Released under the MIT license.
 //
 
-#ifndef EXTC_KEYPATHCODING_H
-#define EXTC_KEYPATHCODING_H
-
 #import <Foundation/Foundation.h>
 #import "metamacros.h"
 
@@ -68,5 +65,3 @@ NSString *lowercaseStringPath = @rac_keypath(NSString.new, lowercaseString);
 #define rac_collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
 
 #define rac_collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(OBJ, PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
-
-#endif

--- a/ReactiveObjC/extobjc/EXTScope.h
+++ b/ReactiveObjC/extobjc/EXTScope.h
@@ -7,9 +7,6 @@
 //  Released under the MIT license.
 //
 
-#ifndef EXTC_EXTSCOPE_H_
-#define EXTC_EXTSCOPE_H_
-
 #import "metamacros.h"
 
 /**
@@ -118,6 +115,4 @@ static inline void rac_executeCleanupBlock (__strong rac_cleanupBlock_t *block) 
 #define rac_keywordify autoreleasepool {}
 #else
 #define rac_keywordify try {} @catch (...) {}
-#endif
-
 #endif


### PR DESCRIPTION
Since these files exist in Foundations as well, only one of them is
imported. A previous commit has diverged the contents of the files,
so it's now safe to remove the guards, in order to files from both
RAC and Foundations to be imported.