### PR TITLE
EXTRuntimeExtensions: Free object before exiting.

### DIFF
--- a/ReactiveObjC/extobjc/EXTRuntimeExtensions.m
+++ b/ReactiveObjC/extobjc/EXTRuntimeExtensions.m
@@ -62,7 +62,7 @@ rac_propertyAttributes *rac_copyPropertyAttributes (objc_property_t property) {
 
         if (!next) {
             fprintf(stderr, "ERROR: Could not read class name in attribute string \"%s\" for property %s\n", attrString, property_getName(property));
-            return NULL;
+            goto errorOut;
         }
 
         if (className != next) {


### PR DESCRIPTION
Fixes a memory leak detected by the static analyzer.