### PR TITLE
ReactiveObjCTests: fix TSan issues.

### DIFF
--- a/ReactiveObjCTests/RACSequenceExamples.m
+++ b/ReactiveObjCTests/RACSequenceExamples.m
@@ -11,6 +11,8 @@
 
 #import "RACSequenceExamples.h"
 
+#import <stdatomic.h>
+
 #import "RACScheduler.h"
 #import "RACSequence.h"
 #import "RACSignal+Operations.h"
@@ -59,8 +61,8 @@ QuickConfigurationBegin(RACSequenceExampleGroups)
 				RACScheduler* scheduler = [RACScheduler schedulerWithPriority:RACSchedulerPriorityHigh];
 				RACSignal *signal = [sequence signalWithScheduler:scheduler];
 
-				__block BOOL flag = YES;
-				__block BOOL completed = NO;
+				__block atomic_bool flag = YES;
+				__block atomic_bool completed = NO;
 				[signal subscribeNext:^(id x) {
 					expect(@(flag)).to(beTruthy());
 					flag = NO;

--- a/ReactiveObjCTests/RACSequenceSpec.m
+++ b/ReactiveObjCTests/RACSequenceSpec.m
@@ -12,6 +12,8 @@
 #import "RACSequenceExamples.h"
 #import "RACStreamExamples.h"
 
+#import <stdatomic.h>
+
 #import "NSArray+RACSequenceAdditions.h"
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACPropertySubscribing.h"
@@ -305,7 +307,7 @@ qck_it(@"shouldn't overflow the stack when deallocated on a background queue", ^
 		[values addObject:@(i)];
 	}
 
-	__block BOOL finished = NO;
+	__block atomic_bool finished = NO;
 	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		@autoreleasepool {
 			(void)[[values.rac_sequence map:^(id value) {

--- a/ReactiveObjCTests/RACSerialDisposableSpec.m
+++ b/ReactiveObjCTests/RACSerialDisposableSpec.m
@@ -11,6 +11,8 @@
 
 #import "RACSerialDisposable.h"
 
+#import <stdatomic.h>
+
 QuickSpecBegin(RACSerialDisposableSpec)
 
 qck_it(@"should initialize with -init", ^{
@@ -138,12 +140,12 @@ qck_it(@"should release the inner disposable upon deallocation", ^{
 });
 
 qck_it(@"should not crash when racing between swapInDisposable and disposable", ^{
-	__block BOOL stop = NO;
+	__block atomic_bool stop = NO;
 	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (long long)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
 		stop = YES;
 	});
 
-	RACSerialDisposable *serialDisposable =  [[RACSerialDisposable alloc] init];
+	RACSerialDisposable *serialDisposable = [[RACSerialDisposable alloc] init];
 	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		while (!stop) {
 			[serialDisposable swapInDisposable:[RACDisposable disposableWithBlock:^{}]];


### PR DESCRIPTION
Most of the fixes involve changing `BOOL` and `NSUInteger` to their
atomic counterparts. Since the original types are atomic on x64 and arm
and the tests only check that eventually they are equal to a specific
value (which implies relaxed ordering), no real difference in the result
of the test is expected.

There were two tests where I needed to change the logic of the test,
since the matcher was expecting a pointer which contains an ObjC value
to change, and since it cannot be expressed by an atomic variable I
changed the expected variable to an `atomic_bool`.