### PR TITLE
RACSignal+Operations: call -finally: block on disposal.

### DIFF
--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -125,7 +125,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// of the receiver.
 - (RACSignal<ValueType> *)initially:(void (^)(void))block RAC_WARN_UNUSED_RESULT;
 
-/// Executes the given block when the signal completes or errors.
+/// Executes the given block when the signal completes, errs or the subscription is disposed.
 - (RACSignal<ValueType> *)finally:(void (^)(void))block RAC_WARN_UNUSED_RESULT;
 
 /// Divides the receiver's `next`s into buffers which deliver every `interval`

--- a/ReactiveObjCTests/RACSignalSpec.m
+++ b/ReactiveObjCTests/RACSignalSpec.m
@@ -3762,6 +3762,11 @@ qck_describe(@"-finally:", ^{
       [subject sendError:nil];
       expect(@(finallyInvoked)).to(beTruthy());
     });
+
+    qck_it(@"should run finally upon disposal", ^{
+      [disposable dispose];
+      expect(@(finallyInvoked)).to(beTruthy());
+    });
   });
 });
 


### PR DESCRIPTION
The current implementation of -finally: doesn't call the block on
subscription disposal, but only on completion or error. This prevents
using this operator as a traditional "finally" directive (like in
exception handlers), and additionally even makes the use-case defined
in RAC documentation for -initially: to be broken.

Based on https://github.com/joomcode/ReactiveObjC/commit/05fd1f66f0e9594bfc0d9fece03e6ab18236b9b6.