### PR TITLE
RACSignal+Operations: make -catch: and -doError: accept nil errors.

### DIFF
--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -41,7 +41,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 
 /// Do the given block on `error`. This should be used to inject side effects
 /// into the signal.
-- (RACSignal<ValueType> *)doError:(void (^)(NSError * _Nonnull error))block RAC_WARN_UNUSED_RESULT;
+- (RACSignal<ValueType> *)doError:(void (^)(NSError * _Nullable error))block RAC_WARN_UNUSED_RESULT;
 
 /// Do the given block on `completed`. This should be used to inject side effects
 /// into the signal.
@@ -385,7 +385,7 @@ _Pragma("clang diagnostic pop")
 - (RACSignal *)takeUntilReplacement:(RACSignal *)replacement RAC_WARN_UNUSED_RESULT;
 
 /// Subscribes to the returned signal when an error occurs.
-- (RACSignal *)catch:(RACSignal * (^)(NSError * _Nonnull error))catchBlock RAC_WARN_UNUSED_RESULT;
+- (RACSignal *)catch:(RACSignal * (^)(NSError * _Nullable error))catchBlock RAC_WARN_UNUSED_RESULT;
 
 /// Subscribes to the given signal when an error occurs.
 - (RACSignal *)catchTo:(RACSignal *)signal RAC_WARN_UNUSED_RESULT;


### PR DESCRIPTION
Since it's possible to create `RACSignal` with `nil` error, these
operators cannot guarantee a non null error.