### PR TITLE
RACSignal: annotate -subscribe: methods to return nullable disposable.

### DIFF
--- a/ReactiveObjC/RACBehaviorSubject.m
+++ b/ReactiveObjC/RACBehaviorSubject.m
@@ -29,7 +29,7 @@
 
 #pragma mark RACSignal
 
-- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
   RACDisposable *subscriptionDisposable = [super subscribe:subscriber];
 
   RACDisposable *schedulingDisposable = [RACScheduler.subscriptionScheduler schedule:^{

--- a/ReactiveObjC/RACChannel.m
+++ b/ReactiveObjC/RACChannel.m
@@ -63,7 +63,7 @@
 
 #pragma mark RACSignal
 
-- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
   return [self.values subscribe:subscriber];
 }
 

--- a/ReactiveObjC/RACDynamicSignal.m
+++ b/ReactiveObjC/RACDynamicSignal.m
@@ -33,7 +33,7 @@
 
 #pragma mark Managing Subscribers
 
-- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
   NSCParameterAssert(subscriber != nil);
 
   RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];

--- a/ReactiveObjC/RACEmptySignal.m
+++ b/ReactiveObjC/RACEmptySignal.m
@@ -51,7 +51,7 @@
 
 #pragma mark Subscription
 
-- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
   NSCParameterAssert(subscriber != nil);
 
   return [RACScheduler.subscriptionScheduler schedule:^{

--- a/ReactiveObjC/RACErrorSignal.m
+++ b/ReactiveObjC/RACErrorSignal.m
@@ -36,7 +36,7 @@
 
 #pragma mark Subscription
 
-- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
   NSCParameterAssert(subscriber != nil);
 
   return [RACScheduler.subscriptionScheduler schedule:^{

--- a/ReactiveObjC/RACReplaySubject.m
+++ b/ReactiveObjC/RACReplaySubject.m
@@ -51,7 +51,7 @@ const NSUInteger RACReplaySubjectUnlimitedCapacity = NSUIntegerMax;
 
 #pragma mark RACSignal
 
-- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
   RACCompoundDisposable *compoundDisposable = [RACCompoundDisposable compoundDisposable];
 
   RACDisposable *schedulingDisposable = [RACScheduler.subscriptionScheduler schedule:^{

--- a/ReactiveObjC/RACReturnSignal.m
+++ b/ReactiveObjC/RACReturnSignal.m
@@ -78,7 +78,7 @@
 
 #pragma mark Subscription
 
-- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
   NSCParameterAssert(subscriber != nil);
 
   return [RACScheduler.subscriptionScheduler schedule:^{

--- a/ReactiveObjC/RACSignal.h
+++ b/ReactiveObjC/RACSignal.h
@@ -394,34 +394,34 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 /// need to end your subscription before it would "naturally" end, either by
 /// completing or erroring. Once the disposable has been disposed, the subscriber
 /// won't receive any more events from the subscription.
-- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber;
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber;
 
 /// Convenience method to subscribe to the `next` event.
 ///
 /// This corresponds to `IObserver<T>.OnNext` in Rx.
-- (RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock;
+- (nullable RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock;
 
 /// Convenience method to subscribe to the `next` and `completed` events.
-- (RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock completed:(void (^)(void))completedBlock;
+- (nullable RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock completed:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to the `next`, `completed`, and `error` events.
-- (RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock error:(void (^)(NSError * _Nullable error))errorBlock completed:(void (^)(void))completedBlock;
+- (nullable RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock error:(void (^)(NSError * _Nullable error))errorBlock completed:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to `error` events.
 ///
 /// This corresponds to the `IObserver<T>.OnError` in Rx.
-- (RACDisposable *)subscribeError:(void (^)(NSError * _Nullable error))errorBlock;
+- (nullable RACDisposable *)subscribeError:(void (^)(NSError * _Nullable error))errorBlock;
 
 /// Convenience method to subscribe to `completed` events.
 ///
 /// This corresponds to the `IObserver<T>.OnCompleted` in Rx.
-- (RACDisposable *)subscribeCompleted:(void (^)(void))completedBlock;
+- (nullable RACDisposable *)subscribeCompleted:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to `next` and `error` events.
-- (RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock error:(void (^)(NSError * _Nullable error))errorBlock;
+- (nullable RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock error:(void (^)(NSError * _Nullable error))errorBlock;
 
 /// Convenience method to subscribe to `error` and `completed` events.
-- (RACDisposable *)subscribeError:(void (^)(NSError * _Nullable error))errorBlock completed:(void (^)(void))completedBlock;
+- (nullable RACDisposable *)subscribeError:(void (^)(NSError * _Nullable error))errorBlock completed:(void (^)(void))completedBlock;
 
 @end
 

--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -556,19 +556,19 @@
 
 @implementation RACSignal (Subscription)
 
-- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
   NSCAssert(NO, @"This method must be overridden by subclasses");
   return nil;
 }
 
-- (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock {
+- (nullable RACDisposable *)subscribeNext:(void (^)(id x))nextBlock {
   NSCParameterAssert(nextBlock != NULL);
   
   RACSubscriber *o = [RACSubscriber subscriberWithNext:nextBlock error:NULL completed:NULL];
   return [self subscribe:o];
 }
 
-- (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock completed:(void (^)(void))completedBlock {
+- (nullable RACDisposable *)subscribeNext:(void (^)(id x))nextBlock completed:(void (^)(void))completedBlock {
   NSCParameterAssert(nextBlock != NULL);
   NSCParameterAssert(completedBlock != NULL);
   
@@ -576,7 +576,7 @@
   return [self subscribe:o];
 }
 
-- (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock completed:(void (^)(void))completedBlock {
+- (nullable RACDisposable *)subscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock completed:(void (^)(void))completedBlock {
   NSCParameterAssert(nextBlock != NULL);
   NSCParameterAssert(errorBlock != NULL);
   NSCParameterAssert(completedBlock != NULL);
@@ -585,21 +585,21 @@
   return [self subscribe:o];
 }
 
-- (RACDisposable *)subscribeError:(void (^)(NSError *error))errorBlock {
+- (nullable RACDisposable *)subscribeError:(void (^)(NSError *error))errorBlock {
   NSCParameterAssert(errorBlock != NULL);
   
   RACSubscriber *o = [RACSubscriber subscriberWithNext:NULL error:errorBlock completed:NULL];
   return [self subscribe:o];
 }
 
-- (RACDisposable *)subscribeCompleted:(void (^)(void))completedBlock {
+- (nullable RACDisposable *)subscribeCompleted:(void (^)(void))completedBlock {
   NSCParameterAssert(completedBlock != NULL);
   
   RACSubscriber *o = [RACSubscriber subscriberWithNext:NULL error:NULL completed:completedBlock];
   return [self subscribe:o];
 }
 
-- (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock {
+- (nullable RACDisposable *)subscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock {
   NSCParameterAssert(nextBlock != NULL);
   NSCParameterAssert(errorBlock != NULL);
   
@@ -607,7 +607,7 @@
   return [self subscribe:o];
 }
 
-- (RACDisposable *)subscribeError:(void (^)(NSError *))errorBlock completed:(void (^)(void))completedBlock {
+- (nullable RACDisposable *)subscribeError:(void (^)(NSError *))errorBlock completed:(void (^)(void))completedBlock {
   NSCParameterAssert(completedBlock != NULL);
   NSCParameterAssert(errorBlock != NULL);
   

--- a/ReactiveObjC/RACSubject.m
+++ b/ReactiveObjC/RACSubject.m
@@ -51,7 +51,7 @@
 
 #pragma mark Subscription
 
-- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
   NSCParameterAssert(subscriber != nil);
 
   RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];


### PR DESCRIPTION
The -subscribe: method family is annotated as returning a `nonnull`
`RACDisposable`. However, some subclasses of `RACSignal` may return a
`nil` disposable in cases where the subscription cannot be disposed of
(mostly in special signals where the subscription begins and terminates
without a way for the user to dispose the subscription in the middle).

To avoid breaking API and to affect performance, annotating the API
correctly seems like a better option than making the code return a
`RACDisposable` in all code paths.