### PR TITLE
RACSignal+Operations: make -switchToLatest complete in all scenarios.

### DIFF
--- a/ReactiveObjC/RACSignal+Operations.m
+++ b/ReactiveObjC/RACSignal+Operations.m
@@ -854,7 +854,7 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 - (RACSignal *)switchToLatest {
   return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
     __block BOOL outerCompleted = NO;
-    __block BOOL innerCompleted = NO;
+    __block BOOL innerCompleted = YES;
     __block NSUInteger currentInnerIndex = 0;
 
     RACSerialDisposable *innerDisposable = [[RACSerialDisposable alloc] init];

--- a/ReactiveObjCTests/RACSignalSpec.m
+++ b/ReactiveObjCTests/RACSignalSpec.m
@@ -1985,6 +1985,13 @@ qck_describe(@"-switchToLatest", ^{
     expect(@(completed)).to(beTruthy());
   });
 
+  qck_it(@"should send completed when the switching signal completes and no signal is sent", ^{
+    expect(@(completed)).to(beFalsy());
+
+    [subject sendCompleted];
+    expect(@(completed)).to(beTruthy());
+  });
+
   qck_it(@"should dispose previous inner signal before subscribing to new inner signal", ^{
     RACSubject *otherSignal = [RACSubject subject];
     RACSignal *signal = [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {


### PR DESCRIPTION
In the new implementation of `-switchToLatest`, we missed a scenario
where the outer signal is created and no inner signals are sent over
that switched signal. In that case the API defines that the signal
should complete.