### PR TITLE
RACNeverSignal: initial commit.

### DIFF
--- a/ReactiveObjC.xcodeproj/project.pbxproj
+++ b/ReactiveObjC.xcodeproj/project.pbxproj
@@ -203,6 +203,14 @@
 		7DFBED6F1CDB926400EE435B /* UIBarButtonItem+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764C619EDA41200A782A9 /* UIBarButtonItem+RACCommandSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B2B786F1F3780C300156B00 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B786E1F3780C300156B00 /* UIKit.framework */; };
 		8B2B78711F3780CA00156B00 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B78701F3780CA00156B00 /* MapKit.framework */; };
+		8B33C23921CA9EC600BB82D2 /* RACNeverSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B33C23721CA9EC600BB82D2 /* RACNeverSignal.h */; };
+		8B33C23A21CA9EC600BB82D2 /* RACNeverSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B33C23821CA9EC600BB82D2 /* RACNeverSignal.m */; };
+		8B33C23B21CAA09500BB82D2 /* RACNeverSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B33C23821CA9EC600BB82D2 /* RACNeverSignal.m */; };
+		8B33C23C21CAA09700BB82D2 /* RACNeverSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B33C23821CA9EC600BB82D2 /* RACNeverSignal.m */; };
+		8B33C23D21CAA09700BB82D2 /* RACNeverSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B33C23821CA9EC600BB82D2 /* RACNeverSignal.m */; };
+		8B33C23F21CBCF3E00BB82D2 /* RACNeverSignalSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B33C23E21CBCF3E00BB82D2 /* RACNeverSignalSpec.m */; };
+		8B33C24021CBD31800BB82D2 /* RACNeverSignalSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B33C23E21CBCF3E00BB82D2 /* RACNeverSignalSpec.m */; };
+		8B33C24121CBD31900BB82D2 /* RACNeverSignalSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B33C23E21CBCF3E00BB82D2 /* RACNeverSignalSpec.m */; };
 		8B9A2B541F26433000E7748D /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646219EDA41200A782A9 /* RACBlockTrampoline.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1046B7A1BFF5661004D8045 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666719EDA57100A782A9 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1046B7B1BFF5662004D8045 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666719EDA57100A782A9 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -775,6 +783,9 @@
 		7DFBED031CDB8C9500EE435B /* ReactiveObjCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactiveObjCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B2B786E1F3780C300156B00 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		8B2B78701F3780CA00156B00 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/MapKit.framework; sourceTree = DEVELOPER_DIR; };
+		8B33C23721CA9EC600BB82D2 /* RACNeverSignal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RACNeverSignal.h; sourceTree = "<group>"; };
+		8B33C23821CA9EC600BB82D2 /* RACNeverSignal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RACNeverSignal.m; sourceTree = "<group>"; };
+		8B33C23E21CBCF3E00BB82D2 /* RACNeverSignalSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RACNeverSignalSpec.m; sourceTree = "<group>"; };
 		A97451331B3A935E00F48E55 /* watchOS-Application.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Application.xcconfig"; sourceTree = "<group>"; };
 		A97451341B3A935E00F48E55 /* watchOS-Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Base.xcconfig"; sourceTree = "<group>"; };
 		A97451351B3A935E00F48E55 /* watchOS-Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Framework.xcconfig"; sourceTree = "<group>"; };
@@ -1294,6 +1305,8 @@
 				D037648719EDA41200A782A9 /* RACMulticastConnection.h */,
 				D037648819EDA41200A782A9 /* RACMulticastConnection.m */,
 				D037648919EDA41200A782A9 /* RACMulticastConnection+Private.h */,
+				8B33C23721CA9EC600BB82D2 /* RACNeverSignal.h */,
+				8B33C23821CA9EC600BB82D2 /* RACNeverSignal.m */,
 				D037648C19EDA41200A782A9 /* RACPassthroughSubscriber.h */,
 				D037648D19EDA41200A782A9 /* RACPassthroughSubscriber.m */,
 				D037648E19EDA41200A782A9 /* RACQueueScheduler.h */,
@@ -1431,6 +1444,7 @@
 				7A7065831A3F8967001E8354 /* RACKVOProxySpec.m */,
 				D037669219EDA60000A782A9 /* RACKVOWrapperSpec.m */,
 				D037669319EDA60000A782A9 /* RACMulticastConnectionSpec.m */,
+				8B33C23E21CBCF3E00BB82D2 /* RACNeverSignalSpec.m */,
 				D037669419EDA60000A782A9 /* RACPropertySignalExamples.h */,
 				D037669519EDA60000A782A9 /* RACPropertySignalExamples.m */,
 				D037669619EDA60000A782A9 /* RACSchedulerSpec.m */,
@@ -1720,6 +1734,7 @@
 				D037656019EDA41200A782A9 /* RACCommand.h in Headers */,
 				D037660419EDA41200A782A9 /* RACTuple.h in Headers */,
 				D03765C619EDA41200A782A9 /* RACScopedDisposable.h in Headers */,
+				8B33C23921CA9EC600BB82D2 /* RACNeverSignal.h in Headers */,
 				D037660019EDA41200A782A9 /* RACTestScheduler.h in Headers */,
 				D037652C19EDA41200A782A9 /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
 				D03764F019EDA41200A782A9 /* NSControl+RACTextSignalSupport.h in Headers */,
@@ -2082,6 +2097,7 @@
 				57A4D1C81BA13D7A00F7D4B1 /* NSInvocation+RACTypeParsing.m in Sources */,
 				57D4769B1C4206F200EFE697 /* UICollectionReusableView+RACSignalSupport.m in Sources */,
 				57A4D1C91BA13D7A00F7D4B1 /* NSNotificationCenter+RACSupport.m in Sources */,
+				8B33C23D21CAA09700BB82D2 /* RACNeverSignal.m in Sources */,
 				7DFBED6E1CDB918900EE435B /* UIBarButtonItem+RACCommandSupport.m in Sources */,
 				57A4D1CA1BA13D7A00F7D4B1 /* NSObject+RACDeallocating.m in Sources */,
 				57A4D1CB1BA13D7A00F7D4B1 /* NSObject+RACDescription.m in Sources */,
@@ -2187,6 +2203,7 @@
 				7DFBED5A1CDB8DE300EE435B /* RACSubjectSpec.m in Sources */,
 				7DFBED5C1CDB8DE300EE435B /* RACSubscriberExamples.m in Sources */,
 				7DFBED5D1CDB8DE300EE435B /* RACSubscriberSpec.m in Sources */,
+				8B33C24121CBD31900BB82D2 /* RACNeverSignalSpec.m in Sources */,
 				7DFBED5E1CDB8DE300EE435B /* RACSubscriptingAssignmentTrampolineSpec.m in Sources */,
 				7DFBED5F1CDB8DE300EE435B /* RACTargetQueueSchedulerSpec.m in Sources */,
 				7DFBED601CDB8DE300EE435B /* RACTupleSpec.m in Sources */,
@@ -2232,6 +2249,7 @@
 				A9B3157D1B3940750001CB9C /* RACCommand.m in Sources */,
 				A9B3157E1B3940750001CB9C /* RACCompoundDisposable.m in Sources */,
 				A9B3157F1B3940750001CB9C /* RACDelegateProxy.m in Sources */,
+				8B33C23C21CAA09700BB82D2 /* RACNeverSignal.m in Sources */,
 				A9B315801B3940750001CB9C /* RACDisposable.m in Sources */,
 				A9B315811B3940750001CB9C /* RACDynamicSequence.m in Sources */,
 				A9B315821B3940750001CB9C /* RACDynamicSignal.m in Sources */,
@@ -2297,6 +2315,7 @@
 				D037666F19EDA57100A782A9 /* EXTRuntimeExtensions.m in Sources */,
 				D037653E19EDA41200A782A9 /* NSString+RACSupport.m in Sources */,
 				D037653619EDA41200A782A9 /* NSString+RACKeyPathUtilities.m in Sources */,
+				8B33C23A21CA9EC600BB82D2 /* RACNeverSignal.m in Sources */,
 				D03764FA19EDA41200A782A9 /* NSDictionary+RACSequenceAdditions.m in Sources */,
 				D037656819EDA41200A782A9 /* RACCompoundDisposableProvider.d in Sources */,
 				D037653A19EDA41200A782A9 /* NSString+RACSequenceAdditions.m in Sources */,
@@ -2392,6 +2411,7 @@
 				D03766BF19EDA60000A782A9 /* NSNotificationCenterRACSupportSpec.m in Sources */,
 				D037670319EDA60000A782A9 /* RACSubjectSpec.m in Sources */,
 				D03766F119EDA60000A782A9 /* RACSchedulerSpec.m in Sources */,
+				8B33C23F21CBCF3E00BB82D2 /* RACNeverSignalSpec.m in Sources */,
 				D03766DF19EDA60000A782A9 /* RACCompoundDisposableSpec.m in Sources */,
 				D03766E519EDA60000A782A9 /* RACDisposableSpec.m in Sources */,
 				D0C3132019EF2D9700984962 /* RACTestObject.m in Sources */,
@@ -2413,6 +2433,7 @@
 				D037662F19EDA41200A782A9 /* UIControl+RACSignalSupport.m in Sources */,
 				D03765C919EDA41200A782A9 /* RACScopedDisposable.m in Sources */,
 				D03764FF19EDA41200A782A9 /* NSEnumerator+RACSequenceAdditions.m in Sources */,
+				8B33C23B21CAA09500BB82D2 /* RACNeverSignal.m in Sources */,
 				D037664719EDA41200A782A9 /* UISegmentedControl+RACSignalSupport.m in Sources */,
 				D03764EB19EDA41200A782A9 /* NSArray+RACSequenceAdditions.m in Sources */,
 				D03765C119EDA41200A782A9 /* RACScheduler.m in Sources */,
@@ -2550,6 +2571,7 @@
 				D03766DC19EDA60000A782A9 /* RACChannelSpec.m in Sources */,
 				D037671A19EDA60000A782A9 /* UIActionSheetRACSupportSpec.m in Sources */,
 				D03766DA19EDA60000A782A9 /* RACChannelExamples.m in Sources */,
+				8B33C24021CBD31800BB82D2 /* RACNeverSignalSpec.m in Sources */,
 				D03766F619EDA60000A782A9 /* RACSequenceExamples.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReactiveObjC/RACNeverSignal.h
+++ b/ReactiveObjC/RACNeverSignal.h
@@ -1,0 +1,21 @@
+//
+//  RACNeverSignal.h
+//  ReactiveObjC
+//
+//  Created by Yaron Inger on 19/12/2018.
+//  Copyright (c) 2018 GitHub, Inc. All rights reserved.
+//
+
+#import "RACSignal.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+// A private `RACSignal` subclasses that never completes, errs or sends a value to any subscriber.
+@interface RACNeverSignal<__covariant ValueType> : RACSignal<ValueType>
+
+/// Creates a new `RACNeverSignal`.
++ (RACSignal<ValueType> *)never;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACNeverSignal.m
+++ b/ReactiveObjC/RACNeverSignal.m
@@ -1,0 +1,39 @@
+//
+//  RACNeverSignal.m
+//  ReactiveObjC-macOS
+//
+//  Created by Yaron Inger on 19/12/2018.
+//  Copyright (c) 2018 GitHub, Inc. All rights reserved.
+//
+
+#import "RACNeverSignal.h"
+
+#import <ReactiveObjC/EXTScope.h>
+
+#import "RACCompoundDisposable.h"
+#import "RACSubscriber.h"
+
+@implementation RACNeverSignal
+
++ (RACSignal *)never {
+  return [[[self alloc] init] setNameWithFormat:@"+never"];
+}
+
+- (nullable RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+  NSCParameterAssert(subscriber != nil);
+
+  RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
+
+  [disposable addDisposable:[RACDisposable disposableWithBlock:^{
+    // Strongly hold the subscriber until the subscription is disposed. This is required since the
+    // subscriber disposes its disposable on dealloc which will terminate the subscription to this
+    // signal.
+    id<RACSubscriber> __unused retainedSubscriber = subscriber;
+  }]];
+
+  [subscriber didSubscribeWithDisposable:disposable];
+
+  return disposable;
+}
+
+@end

--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -13,6 +13,7 @@
 #import "RACEmptySignal.h"
 #import "RACErrorSignal.h"
 #import "RACMulticastConnection.h"
+#import "RACNeverSignal.h"
 #import "NSObject+RACDescription.h"
 #import "RACReplaySubject.h"
 #import "RACReturnSignal.h"
@@ -37,9 +38,7 @@
 }
 
 + (RACSignal *)never {
-  return [[self createSignal:^ RACDisposable * (id<RACSubscriber> subscriber) {
-    return nil;
-  }] setNameWithFormat:@"+never"];
+  return [RACNeverSignal never];
 }
 
 + (RACSignal *)startEagerlyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block {

--- a/ReactiveObjCTests/RACNeverSignalSpec.m
+++ b/ReactiveObjCTests/RACNeverSignalSpec.m
@@ -1,0 +1,115 @@
+//
+//  RACNeverSignalSpec.m
+//  ReactiveObjC
+//
+//  Created by Yaron Inger on 20/12/2018.
+//  Copyright (c) 2018 GitHub, Inc. All rights reserved.
+//
+
+@import Quick;
+@import Nimble;
+
+#import "RACDisposable.h"
+#import "RACNeverSignal.h"
+#import "RACSubscriber+Private.h"
+
+#import "RACSignal+Operations.h"
+
+QuickSpecBegin(RACNeverSignalSpec)
+
+qck_it(@"should not send next, completed or err", ^{
+  RACSignal *signal = [RACNeverSignal never];
+
+  __block BOOL sentEvent = NO;
+  [signal subscribeNext:^(id _Nullable x) {
+    sentEvent = YES;
+  } error:^(NSError *_Nullable error) {
+    sentEvent = YES;
+  } completed:^{
+    sentEvent = YES;
+  }];
+
+  expect(@(sentEvent)).to(beFalsy());
+});
+
+qck_it(@"should not dispose disposable on signal dealloc", ^{
+  RACDisposable *disposable;
+
+  @autoreleasepool {
+    RACSignal *signal = [RACNeverSignal never];
+    disposable = [signal subscribeNext:^(id _Nullable x) {}];
+  }
+
+  expect(@(disposable.isDisposed)).to(beFalsy());
+
+  [disposable dispose];
+});
+
+qck_it(@"should not dispose disposable if returned disposable is weakly held", ^{
+  __weak RACDisposable *disposable;
+
+  @autoreleasepool {
+    RACSignal *signal = [RACNeverSignal never];
+    disposable = [signal subscribeNext:^(id _Nullable x) {}];
+  }
+
+  expect(disposable).notTo(beNil());
+  expect(@(disposable.isDisposed)).to(beFalsy());
+
+  [disposable dispose];
+});
+
+qck_it(@"should not deallocate subscriber if the disposable is not disposed", ^{
+  RACSignal *signal = [RACNeverSignal never];
+
+  RACDisposable *disposable;
+  __weak RACSubscriber *weakSubscriber;
+
+  @autoreleasepool {
+    RACSubscriber *subscriber = [[RACSubscriber alloc] init];
+    disposable = [signal subscribe:subscriber];
+
+    weakSubscriber = subscriber;
+  }
+
+  expect(weakSubscriber).notTo(beNil());
+
+  [disposable dispose];
+});
+
+qck_it(@"should not deallocate subscriber if the signal is deallocated", ^{
+  __weak RACSubscriber *weakSubscriber;
+  RACDisposable *disposable;
+
+  @autoreleasepool {
+    RACSignal *signal = [RACNeverSignal never];
+    RACSubscriber *subscriber = [[RACSubscriber alloc] init];
+    disposable = [signal subscribe:subscriber];
+
+    weakSubscriber = subscriber;
+  }
+
+  expect(weakSubscriber).notTo(beNil());
+
+  [disposable dispose];
+});
+
+qck_it(@"should deallocate subscriber on subscription disposal", ^{
+  RACSignal *signal = [RACNeverSignal never];
+
+  __weak RACSubscriber *weakSubcriber;
+  @autoreleasepool {
+    RACSubscriber *subscriber = [RACSubscriber subscriberWithNext:^(id x) {
+    } error:^(NSError *error) {
+    } completed:^{
+    }];
+
+    weakSubcriber = subscriber;
+
+    [[signal subscribe:subscriber] dispose];
+  }
+
+  expect(weakSubcriber).to(beNil());
+});
+
+QuickSpecEnd

--- a/ReactiveObjCTests/RACSignalSpec.m
+++ b/ReactiveObjCTests/RACSignalSpec.m
@@ -3820,6 +3820,19 @@ qck_describe(@"-finally:", ^{
       expect(@(finallyInvoked)).to(beTruthy());
     });
   });
+
+  qck_it(@"should not call finally on never signal without disposal", ^{
+    __block BOOL finallyInvoked = NO;
+    RACDisposable *disposable = [[[RACSignal never] finally:^{
+      finallyInvoked = YES;
+    }] subscribeNext:^(id x) {}];
+
+    expect(@(finallyInvoked)).to(beFalsy());
+
+    [disposable dispose];
+
+    expect(@(finallyInvoked)).to(beTruthy());
+  });
 });
 
 qck_describe(@"-ignoreValues", ^{


### PR DESCRIPTION
The fix for `finally:` in 45f673b surfaced an issue with `finally:`
operators that are chained to `+[RACSignal never]` signals.

Intuitively, since this signal never completes or errs, the `finally:`
block should be called only on explicit disposal of the subscription.
Instead, the block is called immediately upon subscription. This happens
since `[RACSignal never]` is implemented as an empty dynamic signal
which doesn't retain its subscriber, and thus the subscriber is
deallocated immediately, which disposes the subscription disposable and
calls the block.

The proposed solution implements a new `RACNeverSignal` which uses
`RACPassthroughSubscriber` to create a retain cycle that holds the
subscriber until the subscription is disposed.

This adds additional complexity for `+[RACSignal never]` signals, but
since these signals are used mostly in tests the memory and performance
degradations should be minimal. The potential downside in this change is
having subscriptions that were used to automatically end to leak, but
subscriptions to infinite signals that are not disposed of are already
considered a bug, so this change will only surface the issue.