### PR TITLE
RACReplaySubject: trim objects before -sendNext:.

### DIFF
--- a/ReactiveObjC/RACReplaySubject.m
+++ b/ReactiveObjC/RACReplaySubject.m
@@ -85,11 +85,12 @@ const NSUInteger RACReplaySubjectUnlimitedCapacity = NSUIntegerMax;
 - (void)sendNext:(id)value {
   @synchronized (self) {
     [self.valuesReceived addObject:value ?: RACTupleNil.tupleNil];
-    [super sendNext:value];
-    
+
     if (self.capacity != RACReplaySubjectUnlimitedCapacity && self.valuesReceived.count > self.capacity) {
       [self.valuesReceived removeObjectsInRange:NSMakeRange(0, self.valuesReceived.count - self.capacity)];
     }
+
+    [super sendNext:value];
   }
 }
 

--- a/ReactiveObjCTests/RACSubjectSpec.m
+++ b/ReactiveObjCTests/RACSubjectSpec.m
@@ -186,6 +186,27 @@ qck_describe(@"RACReplaySubject", ^{
 
       expect(@(errorSent)).to(beTruthy());
     });
+
+    qck_it(@"should receive first values when using take: while in subscribeNext:", ^{
+      id firstValue = @"blah";
+      id secondValue = @"more blah";
+
+      NSMutableArray *outerValues = [NSMutableArray array];
+      NSMutableArray *innerValues = [NSMutableArray array];
+
+      [subject subscribeNext:^(id outerValue) {
+        [outerValues addObject:outerValue];
+        [[subject take:1] subscribeNext:^(id innerValue) {
+          [innerValues addObject:innerValue];
+        }];
+      }];
+
+      [subject sendNext:firstValue];
+      [subject sendNext:secondValue];
+
+      expect(outerValues).to(equal(@[firstValue, secondValue]));
+      expect(innerValues).to(equal(@[firstValue, secondValue]));
+    });
   });
 
   qck_describe(@"with an unlimited capacity", ^{
@@ -319,7 +340,7 @@ qck_describe(@"RACReplaySubject", ^{
       [subject sendNext:@1];
 
       dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        __block RACDisposable *disposable = [subject subscribeNext:^(id x) {
+        __block RACDisposable * _Nullable disposable = [subject subscribeNext:^(id x) {
           expect(disposable).notTo(beNil());
 
           [values addObject:x];


### PR DESCRIPTION
The current value storage trimming behavior of `RACReplaySubject` may
produce incorrect result when subscribing to the subject inside its
`-sendNext:`. Trimming the values before calling `-sendNext:` fixes this
issue.