### PR TITLE
RACDelegateProxy: change property from unsafe_unretained to weak.

### DIFF
--- a/ReactiveObjC/RACDelegateProxy.h
+++ b/ReactiveObjC/RACDelegateProxy.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // The delegate to which messages should be forwarded if not handled by
 // any -signalForSelector: applications.
-@property (nonatomic, unsafe_unretained) id rac_proxiedDelegate;
+@property (nonatomic, weak) id rac_proxiedDelegate;
 
 // Creates a delegate proxy capable of responding to selectors from `protocol`.
 - (instancetype)initWithProtocol:(Protocol *)protocol;


### PR DESCRIPTION
Note that rac_proxiedDelegate can be nil since the delegate may be
released (as it's not tied to the original object's lifetime) or
someone may set the delegate to nil explicitly.

See also: https://stackoverflow.com/c/lightricks/questions/426/.