### PR TITLE
RACSignal - Debug Initialization Source POC

### DIFF
--- a/AppDelegate.mm
+++ b/AppDelegate.mm
@@ -7,6 +7,9 @@
 
 #import "AppDelegate.h"
 
+#include <execinfo.h>
+#include <dlfcn.h>
+
 @interface Measurements : NSObject
 
 - (instancetype)initWithCallStackDuration:(NSTimeInterval)callStackDuration
@@ -23,18 +26,40 @@
 @implementation Measurements
 
 + (instancetype)make {
-  auto beforeCallStack = CACurrentMediaTime();
-  auto callStackSymbols = NSThread.callStackSymbols;
-  auto afterCallStack = CACurrentMediaTime();
-  auto callStackDuration = afterCallStack - beforeCallStack;
+//  auto beforeCallStackFetch = CACurrentMediaTime();
+//  auto callStackSymbols = NSThread.callStackSymbols;
+//  auto afterCallStackFetch = CACurrentMediaTime();
+//
+//  auto callStackDuration = afterCallStackFetch - beforeCallStackFetch;
+//
+//  auto perSymbolElementDurations = [NSMutableArray<NSNumber *>
+//                                    arrayWithCapacity:callStackSymbols.count];
+//  for (NSUInteger i = 0; i < callStackSymbols.count; ++i) {
+//    auto before = CACurrentMediaTime();
+//
+//    // Actual evaluation
+//    auto __unused _ = callStackSymbols[i];
+//    auto after = CACurrentMediaTime();
+//
+//    [perSymbolElementDurations addObject:@(after - before)];
+//  }
+
+/// Alternative approach:
+
+  auto maximumAddressesBufferSize = 50;
+  void *addressesBuffer[maximumAddressesBufferSize];
+  auto beforeAddressesFetch = CACurrentMediaTime();
+  auto addressesBufferCount = backtrace(addressesBuffer, maximumAddressesBufferSize);
+  auto afterAddressesFetch = CACurrentMediaTime();
+  auto callStackDuration = afterAddressesFetch - beforeAddressesFetch;
 
   auto perSymbolElementDurations = [NSMutableArray<NSNumber *>
-                                    arrayWithCapacity:callStackSymbols.count];
-  for (NSUInteger i = 0; i < callStackSymbols.count; ++i) {
-    auto before = CACurrentMediaTime();
+                                    arrayWithCapacity:addressesBufferCount];
 
-    // Actual evaluation
-    auto __unused _ = callStackSymbols[i];
+  Dl_info info;
+  for (NSUInteger i = 0; i < addressesBufferCount; ++i) {
+    auto before = CACurrentMediaTime();
+    dladdr(addressesBuffer[i], &info);
     auto after = CACurrentMediaTime();
 
     [perSymbolElementDurations addObject:@(after - before)];

--- a/AppDelegate.mm
+++ b/AppDelegate.mm
@@ -1,0 +1,137 @@
+//
+//  AppDelegate.m
+//  ObjcPlayground
+//
+//  Created by Ofir Gluzman on 08/04/2021.
+//
+
+#import "AppDelegate.h"
+
+@interface Measurements : NSObject
+
+- (instancetype)initWithCallStackDuration:(NSTimeInterval)callStackDuration
+                perSymbolElementDurations:(NSArray<NSNumber *> *)perSymbolElementDurations;
+
++ (instancetype)make;
+
+@property (readonly, nonatomic) NSTimeInterval callStackDuration;
+
+@property (readonly, nonatomic) NSArray<NSNumber *> *perSymbolElementDurations;
+
+@end
+
+@implementation Measurements
+
++ (instancetype)make {
+  auto beforeCallStack = CACurrentMediaTime();
+  auto callStackSymbols = NSThread.callStackSymbols;
+  auto afterCallStack = CACurrentMediaTime();
+  auto callStackDuration = afterCallStack - beforeCallStack;
+
+  auto perSymbolElementDurations = [NSMutableArray<NSNumber *>
+                                    arrayWithCapacity:callStackSymbols.count];
+  for (NSUInteger i = 0; i < callStackSymbols.count; ++i) {
+    auto before = CACurrentMediaTime();
+
+    // Actual evaluation
+    auto __unused _ = callStackSymbols[i];
+    auto after = CACurrentMediaTime();
+
+    [perSymbolElementDurations addObject:@(after - before)];
+  }
+
+  return [[Measurements alloc] initWithCallStackDuration:callStackDuration
+                               perSymbolElementDurations:perSymbolElementDurations];
+}
+
+- (instancetype)initWithCallStackDuration:(NSTimeInterval)callStackDuration
+                perSymbolElementDurations:(NSArray<NSNumber *> *)perSymbolElementDurations {
+  if (self = [super init]) {
+    _callStackDuration = callStackDuration;
+    _perSymbolElementDurations = perSymbolElementDurations;
+  }
+
+  return self;
+}
+
+@end
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+- (Measurements *)method_A_WithCounter:(NSUInteger)counter {
+  if (counter == 0) {
+    return [Measurements make];
+  } else {
+    return [self method_B_WithCounter:counter - 1];
+  }
+}
+
+- (Measurements *)method_B_WithCounter:(NSUInteger)counter {
+  if (counter == 0) {
+    return [Measurements make];
+  } else {
+    return [self method_A_WithCounter:counter - 1];
+  }
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  NSUInteger stackDepth = 5;
+  NSUInteger iterations = 100;
+
+  NSTimeInterval callStackDurationSum = 0;
+
+  auto perSymbolElementDurationsSums = [NSMutableArray<NSNumber *> array];
+
+  for (NSUInteger i = 0; i < iterations; ++i) {
+    auto measurements = [self method_A_WithCounter:stackDepth];
+    callStackDurationSum += measurements.callStackDuration;
+
+    for (NSUInteger j = 0; j < measurements.perSymbolElementDurations.count; ++j) {
+      if (perSymbolElementDurationsSums.count <= j) {
+        [perSymbolElementDurationsSums addObject:measurements.perSymbolElementDurations[j]];
+      } else {
+        // Objective C 😢
+        perSymbolElementDurationsSums[j] =
+            @(perSymbolElementDurationsSums[j].doubleValue +
+              measurements.perSymbolElementDurations[j].doubleValue);
+      }
+    }
+  }
+
+  auto averageCallStackDuration = callStackDurationSum / iterations;
+
+  auto averagePerSymbolElementDurations = [NSMutableArray<NSNumber *> array];
+  for (NSUInteger i = 0; i < perSymbolElementDurationsSums.count; ++i) {
+    averagePerSymbolElementDurations[i] =
+        @(perSymbolElementDurationsSums[i].doubleValue / iterations);
+  }
+
+  NSLog(@"averageCallStackDuration: %g", averageCallStackDuration);
+  NSLog(@"averagePerSymbolElementDurations: %@", averagePerSymbolElementDurations.description);
+
+  return YES;
+}
+
+
+#pragma mark - UISceneSession lifecycle
+
+
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options {
+  // Called when a new scene session is being created.
+  // Use this method to select a configuration to create the new scene with.
+  return [[UISceneConfiguration alloc] initWithName:@"Default Configuration" sessionRole:connectingSceneSession.role];
+}
+
+
+- (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions {
+  // Called when the user discards a scene session.
+  // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+  // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+}
+
+
+@end

--- a/ReactiveObjC.xcodeproj/project.pbxproj
+++ b/ReactiveObjC.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		091B262C261E21970087E92F /* RACSourceSymbolExtractor.m in Sources */ = {isa = PBXBuildFile; fileRef = 091B262A261E21970087E92F /* RACSourceSymbolExtractor.m */; };
+		091B262D261E21970087E92F /* RACSourceSymbolExtractor.m in Sources */ = {isa = PBXBuildFile; fileRef = 091B262A261E21970087E92F /* RACSourceSymbolExtractor.m */; };
+		091B262E261E21970087E92F /* RACSourceSymbolExtractor.h in Headers */ = {isa = PBXBuildFile; fileRef = 091B262B261E21970087E92F /* RACSourceSymbolExtractor.h */; };
+		091B262F261E21970087E92F /* RACSourceSymbolExtractor.h in Headers */ = {isa = PBXBuildFile; fileRef = 091B262B261E21970087E92F /* RACSourceSymbolExtractor.h */; };
 		314304171ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		314304181ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */; };
 		3A17B4A61E8EFDD500C8999E /* RACAnnotations.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A17B4A51E8EFDCD00C8999E /* RACAnnotations.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -763,6 +767,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		091B262A261E21970087E92F /* RACSourceSymbolExtractor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RACSourceSymbolExtractor.m; sourceTree = "<group>"; };
+		091B262B261E21970087E92F /* RACSourceSymbolExtractor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RACSourceSymbolExtractor.h; sourceTree = "<group>"; };
 		314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKAnnotationView+RACSignalSupport.h"; sourceTree = "<group>"; };
 		314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKAnnotationView+RACSignalSupport.m"; sourceTree = "<group>"; };
 		3A17B4A51E8EFDCD00C8999E /* RACAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RACAnnotations.h; sourceTree = "<group>"; };
@@ -1385,6 +1391,8 @@
 				D03764E519EDA41200A782A9 /* UITextField+RACSignalSupport.m */,
 				D03764E619EDA41200A782A9 /* UITextView+RACSignalSupport.h */,
 				D03764E719EDA41200A782A9 /* UITextView+RACSignalSupport.m */,
+				091B262B261E21970087E92F /* RACSourceSymbolExtractor.h */,
+				091B262A261E21970087E92F /* RACSourceSymbolExtractor.m */,
 			);
 			path = ReactiveObjC;
 			sourceTree = "<group>";
@@ -1597,6 +1605,7 @@
 				57A4D22E1BA13D7A00F7D4B1 /* RACSequence.h in Headers */,
 				57A4D22F1BA13D7A00F7D4B1 /* RACSerialDisposable.h in Headers */,
 				57A4D2301BA13D7A00F7D4B1 /* RACSignal.h in Headers */,
+				091B262F261E21970087E92F /* RACSourceSymbolExtractor.h in Headers */,
 				57DC89A81C50679E00E367B7 /* UICollectionReusableView+RACSignalSupport.h in Headers */,
 				57DC89A71C50679700E367B7 /* UIButton+RACCommandSupport.h in Headers */,
 				57A4D2311BA13D7A00F7D4B1 /* RACSignal+Operations.h in Headers */,
@@ -1738,6 +1747,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D037664519EDA41200A782A9 /* UISegmentedControl+RACSignalSupport.h in Headers */,
+				091B262E261E21970087E92F /* RACSourceSymbolExtractor.h in Headers */,
 				D037666419EDA43C00A782A9 /* ReactiveObjC.h in Headers */,
 				D037652519EDA41200A782A9 /* NSObject+RACPropertySubscribing.h in Headers */,
 				D03765B119EDA41200A782A9 /* RACQueueScheduler.h in Headers */,
@@ -2064,6 +2074,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				57D476951C4206EC00EFE697 /* UITableViewCell+RACSignalSupport.m in Sources */,
+				091B262D261E21970087E92F /* RACSourceSymbolExtractor.m in Sources */,
 				57A4D1B21BA13D7A00F7D4B1 /* RACCompoundDisposableProvider.d in Sources */,
 				57D476901C4206D400EFE697 /* UIControl+RACSignalSupportPrivate.m in Sources */,
 				57A4D1B31BA13D7A00F7D4B1 /* RACSignalProvider.d in Sources */,
@@ -2416,6 +2427,7 @@
 				D03764FF19EDA41200A782A9 /* NSEnumerator+RACSequenceAdditions.m in Sources */,
 				8B33C23B21CAA09500BB82D2 /* RACNeverSignal.m in Sources */,
 				D037664719EDA41200A782A9 /* UISegmentedControl+RACSignalSupport.m in Sources */,
+				091B262C261E21970087E92F /* RACSourceSymbolExtractor.m in Sources */,
 				D03764EB19EDA41200A782A9 /* NSArray+RACSequenceAdditions.m in Sources */,
 				D03765C119EDA41200A782A9 /* RACScheduler.m in Sources */,
 				D037662B19EDA41200A782A9 /* UICollectionReusableView+RACSignalSupport.m in Sources */,

--- a/ReactiveObjC/RACPassthroughSubscriber.h
+++ b/ReactiveObjC/RACPassthroughSubscriber.h
@@ -26,4 +26,10 @@
 // Returns an initialized passthrough subscriber.
 - (instancetype)initWithSubscriber:(id<RACSubscriber>)subscriber signal:(RACSignal *)signal disposable:(RACCompoundDisposable *)disposable;
 
+#ifdef DEBUG
+
+@property (readonly, nonatomic) NSString *signalInitializationSourceSymbol;
+
+#endif
+
 @end

--- a/ReactiveObjC/RACPassthroughSubscriber.m
+++ b/ReactiveObjC/RACPassthroughSubscriber.m
@@ -65,6 +65,14 @@ static const char *cleanedSignalDescription(RACSignal *signal) {
   return self;
 }
 
+#ifdef DEBUG
+
+- (NSString *)signalInitializationSourceSymbol {
+  return self.signal.initializationSourceSymbol;
+}
+
+#endif
+
 #pragma mark RACSubscriber
 
 - (void)sendNext:(id)value {

--- a/ReactiveObjC/RACSignal.h
+++ b/ReactiveObjC/RACSignal.h
@@ -87,6 +87,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// given to `block` and replay any missed events to new subscribers.
 + (RACSignal<ValueType> *)startLazilyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block RAC_WARN_UNUSED_RESULT;
 
+#ifdef DEBUG
+
+@property (readonly, nonatomic) NSString *initializationSourceSymbol;
+
+#endif
+
 @end
 
 @interface RACSignal<__covariant ValueType> (RACStream)

--- a/ReactiveObjC/RACSourceSymbolExtractor.h
+++ b/ReactiveObjC/RACSourceSymbolExtractor.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2021 Lightricks. All rights reserved.
+// Created by Ofir Gluzman.
+
+#if DEBUG
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NSString *RACExtractSourceSymbol(NSArray<NSString *> *callStackSymbols);
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/ReactiveObjC/RACSourceSymbolExtractor.h
+++ b/ReactiveObjC/RACSourceSymbolExtractor.h
@@ -7,7 +7,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NSString *RACExtractSourceSymbol(NSArray<NSString *> *callStackSymbols);
+NSString * _Nullable RACExtractSourceSymbol(void * _Nonnull * _Nonnull addresses,
+                                            NSUInteger addressesCount);
 
 NS_ASSUME_NONNULL_END
 

--- a/ReactiveObjC/RACSourceSymbolExtractor.m
+++ b/ReactiveObjC/RACSourceSymbolExtractor.m
@@ -5,38 +5,23 @@
 
 #import "RACSourceSymbolExtractor.h"
 
+#include <dlfcn.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
-NSString *RACExtractSourceSymbol(NSArray<NSString *> *callStackSymbols) {
-  static NSString * const kPattern = @"[0-9]+[\\s]+([\\S]+)[ ]+0x[0-9,a-f]+ (.*?) \\+ ([0-9]+)";
+NSString *RACExtractSourceSymbol(void **addresses, NSUInteger addressesCount) {
   static NSString * const kRACLibraryName = @"ReactiveObjC";
 
-  NSError *error;
-  NSRegularExpression * _Nullable regex = [NSRegularExpression
-                                           regularExpressionWithPattern:kPattern
-                                           options:0 error:&error];
-  NSCAssert(regex != nil, @"Failed to create regex: %@", error);
-
-  for (NSUInteger i = 0; i < callStackSymbols.count; ++i) {
-    NSArray<NSTextCheckingResult *> *matches = [regex
-                                                matchesInString:callStackSymbols[i] options:0
-                                                range:NSMakeRange(0, callStackSymbols[i].length)];
-    NSCAssert(matches.count == 1, @"Number of matches (%lu) is expected to be exactly 1",
-              (unsigned long)matches.count);
-    NSCAssert(matches[0].numberOfRanges == 4, @"Number of ranges (%lu) is expected to be exactly 4",
-              (unsigned long)matches[0].numberOfRanges);
-
-    NSString *libraryName = [callStackSymbols[i] substringWithRange:[matches[0] rangeAtIndex:1]];
-
-    if (![libraryName isEqual:kRACLibraryName]) {
-      NSString *methodSymbol = [callStackSymbols[i] substringWithRange:[matches[0] rangeAtIndex:2]];
-      return methodSymbol;
+  Dl_info info;
+  for (NSUInteger i = 0; i < addressesCount; ++i) {
+    dladdr(addresses[i], &info);
+    NSString *frameworkPath = [NSString stringWithUTF8String:info.dli_fname];
+    if (![[frameworkPath pathComponents].lastObject isEqual:kRACLibraryName]) {
+      return [NSString stringWithUTF8String:info.dli_sname];
     }
   }
 
-  NSCAssert(NO, @"Reached the end of the call stack (%@) without finding a source",
-            callStackSymbols);
-  return @"";
+  return nil;
 }
 
 

--- a/ReactiveObjC/RACSourceSymbolExtractor.m
+++ b/ReactiveObjC/RACSourceSymbolExtractor.m
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Lightricks. All rights reserved.
+// Created by Ofir Gluzman.
+
+#if DEBUG
+
+#import "RACSourceSymbolExtractor.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+NSString *RACExtractSourceSymbol(NSArray<NSString *> *callStackSymbols) {
+  static NSString * const kPattern = @"[0-9]+[\\s]+([\\S]+)[ ]+0x[0-9,a-f]+ (.*?) \\+ ([0-9]+)";
+  static NSString * const kRACLibraryName = @"ReactiveObjC";
+
+  NSError *error;
+  NSRegularExpression * _Nullable regex = [NSRegularExpression
+                                           regularExpressionWithPattern:kPattern
+                                           options:0 error:&error];
+  NSCAssert(regex != nil, @"Failed to create regex: %@", error);
+
+  for (NSUInteger i = 0; i < callStackSymbols.count; ++i) {
+    NSArray<NSTextCheckingResult *> *matches = [regex
+                                                matchesInString:callStackSymbols[i] options:0
+                                                range:NSMakeRange(0, callStackSymbols[i].length)];
+    NSCAssert(matches.count == 1, @"Number of matches (%lu) is expected to be exactly 1",
+              (unsigned long)matches.count);
+    NSCAssert(matches[0].numberOfRanges == 4, @"Number of ranges (%lu) is expected to be exactly 4",
+              (unsigned long)matches[0].numberOfRanges);
+
+    NSString *libraryName = [callStackSymbols[i] substringWithRange:[matches[0] rangeAtIndex:1]];
+
+    if (![libraryName isEqual:kRACLibraryName]) {
+      NSString *methodSymbol = [callStackSymbols[i] substringWithRange:[matches[0] rangeAtIndex:2]];
+      return methodSymbol;
+    }
+  }
+
+  NSCAssert(NO, @"Reached the end of the call stack (%@) without finding a source",
+            callStackSymbols);
+  return @"";
+}
+
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/rac_signal_source_symbol_tracer.py
+++ b/rac_signal_source_symbol_tracer.py
@@ -1,0 +1,46 @@
+# !!! Full path to this file should be set up locally on ~/.lldbinit by by adding a line:
+# `command script import <full path to this file>
+
+import lldb
+
+def __lldb_init_module(debugger, dict):
+  lldb.debugger.HandleCommand("type synthetic add RACPassthroughSubscriber --python-class " + 
+      "rac_signal_source_symbol_tracer.RACSignalSourceSymbolTracer")
+
+def evaluateExpressionValue(expression, printErrors = True):
+  # lldb.frame is supposed to contain the right frame, but it doesnt :/ so do the dance
+  frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
+  value = frame.EvaluateExpression(expression)
+  if printErrors and value.GetError() is not None and str(value.GetError()) != 'success':
+    print(value.GetError())
+  return value
+
+
+class RACSignalSourceSymbolTracer:
+  SIGNAL_SOURCE_SYMBOL_CHILD_NAME = "signalSourceSymbol"
+
+  def __init__(self, valobj, dict):
+    self.valobj = valobj
+    self.signalSourceMethodSymbol = self.valobj.CreateValueFromExpression(RACSignalSourceSymbolTracer.SIGNAL_SOURCE_SYMBOL_CHILD_NAME,
+      "(NSString *)[%s signalInitializationSourceSymbol]" % self.valobj.GetName())
+
+  def num_children(self):
+    return self.valobj.GetNumChildren() + 1
+
+  def get_child_index(self, name):
+    if name == RACSignalSourceSymbolTracer.SIGNAL_SOURCE_SYMBOL_CHILD_NAME:
+      return 0
+    else:
+      return self.valobj.GetChildMemberWithName(name) + 1
+
+  def get_child_at_index(self, index):
+    if index == 0:
+      return self.signalSourceMethodSymbol
+    else:
+      return self.valobj.GetChildAtIndex(index - 1)
+
+  def update(self):
+    pass
+
+  def has_children(self):
+    return True


### PR DESCRIPTION
@barakyoresh @barakwei following our discussion - here is a draft PR for the feature. 

Pipeline:
1. Save the symbols of the call stack upon init of `RACSignal` by calling `NSThread.callStackSymbols` - this is a lightweight operation as the symbolication of the callstack elements in `NSThread.callStackSymbols` is done lazily when accessing the elements. This call only saves the callstack addresses. This is of course important to be lightweight as signals are initialized a lot...
2.  Upon debug session extract (lazily) from the call stack the first symbol that is not part of the RAC library. This is a heavy operation that binds each address from the saved callstack to its symbol. This is done by evaluating `RACPassthroughSubscriber.signalInitializationSourceSymbol` property which triggers the evaluation of the symbol on its `RACSignal`. The call to this property can be done automatically by the debugger by adding a python script (also attached in the PR) and installing it locally. The code in the python script is not very interesting - I copied it from Yaron's script for creating an `LTImage` to an openCV mat on debug and only changed the parameters to fit.

Your input is welcomed, if we can extract other information like the file name and line that can of course be really cool.


